### PR TITLE
feat: Refactor user home dir management, env setup, and Sliver build

### DIFF
--- a/roles/sliver/defaults/main.yml
+++ b/roles/sliver/defaults/main.yml
@@ -7,5 +7,5 @@ sliver_usergroup: "sliver"
 sliver_shell: "{% if ansible_os_family == 'Darwin' %}/bin/zsh{% else %}/bin/bash{% endif %}"
 sliver_asdf_plugins:
   - name: golang
-    version: "1.24.0"
+    version: "1.22.2"
     scope: "global"

--- a/roles/sliver/tasks/main.yml
+++ b/roles/sliver/tasks/main.yml
@@ -17,7 +17,7 @@
         shell: "{{ sliver_shell }}"
         sudo: true
 
-- name: Include sliver_get_user_home tasks
+- name: Set sliver user home directory
   ansible.builtin.include_tasks: sliver_get_user_home.yml
 
 - name: Ensure home directory exists for sliver user
@@ -29,23 +29,23 @@
     mode: '0750'
   become: true
 
-- name: Check if .bash_profile exists for sliver user
+- name: Check if .bashrc exists for sliver user
   ansible.builtin.stat:
-    path: "{{ sliver_user_home }}/.bash_profile"
-  register: bash_profile_stat
+    path: "{{ sliver_user_home }}/.bashrc"
+  register: bashrc_stat
   become: true
 
-- name: Ensure .bash_profile exists for sliver user
+- name: Ensure .bashrc exists for sliver user
   ansible.builtin.file:
-    path: "{{ sliver_user_home }}/.bash_profile"
+    path: "{{ sliver_user_home }}/.bashrc"
     state: touch
     owner: "{{ sliver_username }}"
     group: "{{ sliver_usergroup }}"
     mode: '0644'
   become: true
-  when: not bash_profile_stat.stat.exists
+  when: not bashrc_stat.stat.exists
 
-- name: Check if asdf is installed for sliver user
+- name: Check if ASDF is installed for sliver user
   ansible.builtin.stat:
     path: "{{ sliver_user_home }}/.asdf"
   register: asdf_installed
@@ -54,6 +54,11 @@
   ansible.builtin.stat:
     path: "/usr/local/bin/asdf"
   register: asdf_binary_installed
+
+# Print slive3r user info
+- name: Print sliver user info
+  ansible.builtin.debug:
+    msg: "Sliver user info: {{ sliver_username }}, {{ sliver_usergroup }}, {{ sliver_shell }}, {{ sliver_user_home }}"
 
 - name: Install asdf and golang for sliver user
   ansible.builtin.include_role:

--- a/roles/sliver/tasks/setup.yml
+++ b/roles/sliver/tasks/setup.yml
@@ -45,7 +45,7 @@
 
 - name: Add sliver_install_path to $PATH
   ansible.builtin.lineinfile:
-    path: "{{ sliver_user_home }}/.bash_profile"
+    path: "{{ sliver_user_home }}/.bashrc"
     line: "export PATH=$PATH:{{ sliver_install_path }}"
     insertafter: EOF
     regexp: "^export PATH=.*:{{ sliver_install_path }}.*$"
@@ -60,11 +60,19 @@
 
 - name: Ensure golang is installed for user
   ansible.builtin.shell: |
-    export ASDF_DATA_DIR="/home/{{ sliver_username }}/.asdf"
+    export ASDF_DATA_DIR="{{ sliver_user_home }}/.asdf"
     export PATH="/usr/local/bin:$PATH"
+
+    # Uninstall golang first if it exists
     asdf uninstall golang {{ sliver_asdf_plugins[0].version }} || true
+
+    # Install golang version
     asdf install golang {{ sliver_asdf_plugins[0].version }}
+
+    # Set the golang version
     asdf set --home golang {{ sliver_asdf_plugins[0].version }}
+
+    # Reshim to ensure shims are created
     asdf reshim golang
   args:
     executable: /bin/bash
@@ -77,35 +85,52 @@
   when: not sliver_server_stat.stat.exists
   changed_when: false
 
-- name: Compile Sliver
+- name: Compile sliver
   ansible.builtin.shell: |
     set -o pipefail
-    export ASDF_DATA_DIR="/home/{{ sliver_username }}/.asdf"
+
+    # Check asdf is available and working
+    export ASDF_DATA_DIR="{{ sliver_user_home }}/.asdf"
     export PATH="/usr/local/bin:${ASDF_DATA_DIR}/shims:$PATH"
     asdf --version
+
+    # Reshim and verify golang version
     asdf reshim golang
     asdf current golang
+
+    # Ensure go binary is available
     GO_BIN_PATH=$(find "${ASDF_DATA_DIR}/installs/golang/{{ sliver_asdf_plugins[0].version }}" -name go -type f -executable | head -1)
+
     if [ -z "$GO_BIN_PATH" ]; then
       echo "Could not find go binary in standard location, checking alternative paths..."
       GO_BIN_PATH=$(find "${ASDF_DATA_DIR}/installs/golang" -name go -type f -executable | head -1)
     fi
+
     if [ -z "$GO_BIN_PATH" ]; then
       echo "Still could not find go binary, checking shims directory..."
       if [ -x "${ASDF_DATA_DIR}/shims/go" ]; then
         GO_BIN_PATH="${ASDF_DATA_DIR}/shims/go"
       fi
     fi
+
     if [ -z "$GO_BIN_PATH" ]; then
       echo "ERROR: Could not find go executable anywhere"
       exit 1
     fi
+
     echo "Found Go binary at: ${GO_BIN_PATH}"
+
+    # Verify Go works
     echo "Running Go version check:"
     "$GO_BIN_PATH" version
-    cd {{ sliver_install_path }}
+
+    # Run go mod tidy to update dependencies
+    echo "Running go mod tidy to update dependencies:"
+    "$GO_BIN_PATH" mod tidy
+
+    # Build the sliver binary using the direct path to Go
     echo "Building sliver binary:"
-    {{ 'make' if ansible_distribution == 'Kali GNU/Linux' else 'gmake' }} -j{{ ansible_processor_vcpus | default(2) }}
+    {{ 'make' if ansible_distribution == 'Kali GNU/Linux' else 'gmake' }} -C {{ sliver_install_path }} -j{{ ansible_processor_vcpus | default(2) }}
   args:
     chdir: "{{ sliver_install_path }}"
     executable: /bin/bash
@@ -122,13 +147,13 @@
     GIT_SSL_CAINFO: "/etc/ssl/certs/ca-certificates.crt"
     SSL_CERT_FILE: "/etc/ssl/certs/ca-certificates.crt"
   when: not sliver_server_stat.stat.exists
+  tags:
+    - molecule-idempotence-notest
+  changed_when: "'molecule-idempotence-notest' not in ansible_skip_tags"
   register: compile_result
   failed_when:
     - compile_result.rc != 0
     - "'No executable go found' not in compile_result.stderr"
-  tags:
-    - molecule-idempotence-notest
-  changed_when: "'molecule-idempotence-notest' not in ansible_skip_tags"
 
 - name: Check if Sliver server unpacked
   ansible.builtin.stat:
@@ -146,10 +171,10 @@
   changed_when: "'Unpacking complete' in unpack_result.stdout"
   register: unpack_result
   environment:
-    HOME: "/home/{{ sliver_username }}"
+    HOME: "{{ sliver_user_home }}"
     USER: "{{ sliver_username }}"
-    ASDF_DATA_DIR: "/home/{{ sliver_username }}/.asdf"
-    PATH: "/usr/local/bin:/home/{{ sliver_username }}/.asdf/shims:/usr/bin:/bin"
+    ASDF_DATA_DIR: "{{ sliver_user_home }}/.asdf"
+    PATH: "/usr/local/bin:/{{ sliver_user_home }}/.asdf/shims:/usr/bin:/bin"
 
 - name: Generate operator config
   ansible.builtin.shell:
@@ -158,6 +183,7 @@
       --lhost localhost --save "{{ sliver_install_path }}/sliver-client/configs"
       chown -R {{ sliver_username }}:"{{ sliver_usergroup }}" "{{ sliver_install_path }}/sliver-client"
   become: true
+  become_user: "{{ sliver_username }}"
   args:
     executable: /bin/bash
   changed_when: "'configs saved' in result.stdout"

--- a/roles/sliver/tasks/setup.yml
+++ b/roles/sliver/tasks/setup.yml
@@ -11,7 +11,6 @@
     repo: 'https://github.com/bishopfox/sliver.git'
     dest: "{{ sliver_install_path }}"
     version: master
-    depth: 1
     force: true
     update: true
   become: true

--- a/roles/ttpforge/tasks/main.yml
+++ b/roles/ttpforge/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Set ttpforge user home directory
+  ansible.builtin.include_tasks: ttpforge_get_user_home.yml
+
 - name: Install required packages for ttpforge
   ansible.builtin.include_role:
     name: cowdogmoo.workstation.package_management
@@ -7,32 +10,32 @@
 
 - name: Ensure home directory exists for ttpforge user
   ansible.builtin.file:
-    path: "/home/{{ ttpforge_username }}"
+    path: "{{ ttpforge_user_home }}"
     state: directory
     owner: "{{ ttpforge_username }}"
     group: "{{ ttpforge_usergroup }}"
     mode: '0750'
   become: true
 
-- name: Check if .bash_profile exists for ttpforge user
+- name: Check if .bashrc exists for ttpforge user
   ansible.builtin.stat:
-    path: "/home/{{ ttpforge_username }}/.bash_profile"
-  register: bash_profile_stat
+    path: "{{ ttpforge_user_home }}/.bashrc"
+  register: bashrc_stat
   become: true
 
-- name: Ensure .bash_profile exists for ttpforge user
+- name: Ensure .bashrc exists for ttpforge user
   ansible.builtin.file:
-    path: "/home/{{ ttpforge_username }}/.bash_profile"
+    path: "{{ ttpforge_user_home }}/.bashrc"
     state: touch
     owner: "{{ ttpforge_username }}"
     group: "{{ ttpforge_usergroup }}"
     mode: '0644'
   become: true
-  when: not bash_profile_stat.stat.exists
+  when: not bashrc_stat.stat.exists
 
 - name: Check if asdf is installed for ttpforge user
   ansible.builtin.stat:
-    path: "/home/{{ ttpforge_username }}/.asdf"
+    path: "{{ ttpforge_user_home }}/.asdf"
   register: asdf_installed
 
 - name: Check if asdf binary is installed
@@ -48,8 +51,8 @@
     asdf_usergroup: "{{ ttpforge_usergroup }}"
     asdf_shell: "{{ ttpforge_shell }}"
     asdf_plugins: "{{ ttpforge_asdf_plugins }}"
-    asdf_user_home: "/home/{{ ttpforge_username }}"
-    asdf_data_dir: "/home/{{ ttpforge_username }}/.asdf"
+    asdf_user_home: "{{ ttpforge_user_home }}"
+    asdf_data_dir: "{{ ttpforge_user_home }}/.asdf"
     asdf_bin_dir: "/usr/local/bin"
   when: not asdf_installed.stat.exists or not asdf_binary_installed.stat.exists
 

--- a/roles/ttpforge/tasks/setup.yml
+++ b/roles/ttpforge/tasks/setup.yml
@@ -47,7 +47,7 @@
 
 - name: Add ttpforge_install_path to $PATH
   ansible.builtin.lineinfile:
-    path: "/home/{{ ttpforge_username }}/.bash_profile"
+    path: "{{ ttpforge_user_home }}/.bashrc"
     line: "export PATH=$PATH:{{ ttpforge_install_path }}"
     insertafter: EOF
     regexp: "^export PATH=.*:{{ ttpforge_install_path }}.*$"
@@ -58,10 +58,11 @@
   ansible.builtin.stat:
     path: "{{ ttpforge_install_path }}/ttpforge"
   register: ttpforge_binary_stat
+  become: true
 
 - name: Ensure golang is installed for user
   ansible.builtin.shell: |
-    export ASDF_DATA_DIR="/home/{{ ttpforge_username }}/.asdf"
+    export ASDF_DATA_DIR="{{ ttpforge_user_home }}/.asdf"
     export PATH="/usr/local/bin:$PATH"
 
     # Uninstall golang first if it exists
@@ -80,9 +81,9 @@
   become: true
   become_user: "{{ ttpforge_username }}"
   environment:
-    HOME: "/home/{{ ttpforge_username }}"
+    HOME: "{{ ttpforge_user_home }}"
     USER: "{{ ttpforge_username }}"
-    ASDF_DATA_DIR: "/home/{{ ttpforge_username }}/.asdf"
+    ASDF_DATA_DIR: "{{ ttpforge_user_home }}/.asdf"
   when: not ttpforge_binary_stat.stat.exists
   changed_when: false
 
@@ -91,7 +92,7 @@
     set -o pipefail
 
     # Check asdf is available and working
-    export ASDF_DATA_DIR="/home/{{ ttpforge_username }}/.asdf"
+    export ASDF_DATA_DIR="{{ ttpforge_user_home }}/.asdf"
     export PATH="/usr/local/bin:${ASDF_DATA_DIR}/shims:$PATH"
     asdf --version
 
@@ -138,12 +139,12 @@
   become: true
   become_user: "{{ ttpforge_username }}"
   environment:
-    HOME: "/home/{{ ttpforge_username }}"
+    HOME: "{{ ttpforge_user_home }}"
     USER: "{{ ttpforge_username }}"
-    ASDF_DATA_DIR: "/home/{{ ttpforge_username }}/.asdf"
-    PATH: "/usr/local/bin:/home/{{ ttpforge_username }}/.asdf/shims:/usr/bin:/bin"
+    ASDF_DATA_DIR: "{{ ttpforge_user_home }}/.asdf"
+    PATH: "/usr/local/bin:{{ ttpforge_user_home }}/.asdf/shims:/usr/bin:/bin"
     GO111MODULE: "on"
-    GOPATH: "/home/{{ ttpforge_username }}/go"
+    GOPATH: "{{ ttpforge_user_home }}/go"
   when: not ttpforge_binary_stat.stat.exists
   tags:
     - molecule-idempotence-notest


### PR DESCRIPTION
**Key Changes:**

- Refactored home dir logic to use `ttpforge_user_home` and `sliver_user_home`
  vars for dynamic path resolution across all roles and tasks.
- Switched shell config handling from `.bash_profile` to `.bashrc` for
  PATH export, file checks, and handling user env.
- Improved Sliver role: added debug info, robust go install/build,
  and Golang version management.
- Removed git clone `depth: 1` to fix sliver-server panic after build.

**Added:**

- New debug tasks printing user info for troubleshooting.
- Reshim logic after go install and prior to build for reliability.

**Changed:**

- Full use of `*_user_home` vars everywhere for home dir refs.
- asdf/Golang install ensures uninstall/reinstall of correct version.
- Golang version update from 1.24.0 to 1.22.2 for compatibility.
- Enhanced Sliver build: checks for `go` binary, uses `gmake -C`,
  and adds `go mod tidy` for deps.
- Consistent env setup with $HOME/$USER in config tasks.
- Improved molecule test patterns; whitespace/comments cleanup.
- All legacy `.bash_profile` usage replaced with `.bashrc`.

**Removed:**

- Shallow (`depth: 1`) git clone of Sliver, resolving build panics.
- Legacy `.bash_profile` references (favoring `.bashrc`).