### PR TITLE
feat: Improve Sliver role setup and Molecule verification

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -201,7 +201,7 @@ jobs:
       - name: Install Act dependencies
         if: ${{ env.ACT }}
         run: |
-          apt-get update && apt-get install rsync sudo -y
+          apt-get -y update && apt-get install rsync sudo
 
       - name: Delete huge unnecessary tools folder
         if: env.ACT == ''

--- a/playbooks/atomic-red-team/molecule/default/create.yml
+++ b/playbooks/atomic-red-team/molecule/default/create.yml
@@ -1,0 +1,41 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    molecule_labels:
+      owner: molecule
+  tasks:
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: lookup('env', 'HOME') | length > 0
+
+    - name: Create molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
+        image: "{{ item.image }}"
+        command: "{{ item.command | default('') }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
+      register: server
+      loop: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      delay: 1
+      loop: "{{ server.results }}"

--- a/playbooks/atomic-red-team/molecule/default/destroy.yml
+++ b/playbooks/atomic-red-team/molecule/default/destroy.yml
@@ -1,0 +1,14 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+      when: molecule_yml.platforms is defined

--- a/playbooks/attack_box/molecule/default/create.yml
+++ b/playbooks/attack_box/molecule/default/create.yml
@@ -1,0 +1,41 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    molecule_labels:
+      owner: molecule
+  tasks:
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: lookup('env', 'HOME') | length > 0
+
+    - name: Create molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
+        image: "{{ item.image }}"
+        command: "{{ item.command | default('') }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
+      register: server
+      loop: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      delay: 1
+      loop: "{{ server.results }}"

--- a/playbooks/attack_box/molecule/default/destroy.yml
+++ b/playbooks/attack_box/molecule/default/destroy.yml
@@ -1,0 +1,14 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+      when: molecule_yml.platforms is defined

--- a/playbooks/sliver/molecule/default/create.yml
+++ b/playbooks/sliver/molecule/default/create.yml
@@ -1,0 +1,41 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    molecule_labels:
+      owner: molecule
+  tasks:
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: lookup('env', 'HOME') | length > 0
+
+    - name: Create molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
+        image: "{{ item.image }}"
+        command: "{{ item.command | default('') }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
+      register: server
+      loop: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      delay: 1
+      loop: "{{ server.results }}"

--- a/playbooks/sliver/molecule/default/destroy.yml
+++ b/playbooks/sliver/molecule/default/destroy.yml
@@ -1,0 +1,14 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+      when: molecule_yml.platforms is defined

--- a/playbooks/ttpforge/molecule/default/create.yml
+++ b/playbooks/ttpforge/molecule/default/create.yml
@@ -1,0 +1,41 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    molecule_labels:
+      owner: molecule
+  tasks:
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: lookup('env', 'HOME') | length > 0
+
+    - name: Create molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
+        image: "{{ item.image }}"
+        command: "{{ item.command | default('') }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
+      register: server
+      loop: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      delay: 1
+      loop: "{{ server.results }}"

--- a/playbooks/ttpforge/molecule/default/destroy.yml
+++ b/playbooks/ttpforge/molecule/default/destroy.yml
@@ -1,0 +1,14 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+      when: molecule_yml.platforms is defined

--- a/roles/attack_box/molecule/default/create.yml
+++ b/roles/attack_box/molecule/default/create.yml
@@ -1,0 +1,41 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    molecule_labels:
+      owner: molecule
+  tasks:
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: lookup('env', 'HOME') | length > 0
+
+    - name: Create molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
+        image: "{{ item.image }}"
+        command: "{{ item.command | default('') }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
+      register: server
+      loop: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      delay: 1
+      loop: "{{ server.results }}"

--- a/roles/attack_box/molecule/default/destroy.yml
+++ b/roles/attack_box/molecule/default/destroy.yml
@@ -1,0 +1,14 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+      when: molecule_yml.platforms is defined

--- a/roles/sliver/molecule/default/create.yml
+++ b/roles/sliver/molecule/default/create.yml
@@ -1,0 +1,41 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    molecule_labels:
+      owner: molecule
+  tasks:
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: lookup('env', 'HOME') | length > 0
+
+    - name: Create molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
+        image: "{{ item.image }}"
+        command: "{{ item.command | default('') }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
+      register: server
+      loop: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      delay: 1
+      loop: "{{ server.results }}"

--- a/roles/sliver/molecule/default/destroy.yml
+++ b/roles/sliver/molecule/default/destroy.yml
@@ -1,0 +1,14 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+      when: molecule_yml.platforms is defined

--- a/roles/sliver/molecule/default/verify.yml
+++ b/roles/sliver/molecule/default/verify.yml
@@ -8,6 +8,9 @@
       ansible.builtin.include_vars:
         file: "../../defaults/main.yml"
 
+    - name: Set sliver user home directory
+      ansible.builtin.include_tasks: "../../tasks/sliver_get_user_home.yml"
+
     - name: Check if Sliver server is installed
       ansible.builtin.stat:
         path: "{{ sliver_install_path }}/sliver-server"

--- a/roles/sliver/molecule/default/verify.yml
+++ b/roles/sliver/molecule/default/verify.yml
@@ -20,6 +20,9 @@
       ansible.builtin.stat:
         path: "{{ sliver_install_path }}/sliver-client"
       register: sliver_client
+      failed_when: >
+        not sliver_client.stat.exists or
+        not sliver_client.stat.executable
 
     - name: Check sliver user exists
       ansible.builtin.command: "id -un {{ sliver_username }}"
@@ -32,3 +35,14 @@
         path: "/etc/sudoers.d/{{ sliver_username }}"
       register: sudoers_check
       when: sliver_username != 'root'
+      failed_when: >
+        sliver_username != 'root' and
+        not sudoers_check.stat.exists
+
+    - name: Check if operator config exists
+      ansible.builtin.stat:
+        path: "{{ sliver_user_home }}/.sliver-client/configs/{{ sliver_username }}_localhost.cfg"
+      register: operator_config
+      failed_when: >
+        not operator_config.stat.exists or
+        operator_config.stat.size == 0

--- a/roles/sliver/tasks/setup.yml
+++ b/roles/sliver/tasks/setup.yml
@@ -175,17 +175,32 @@
     ASDF_DATA_DIR: "{{ sliver_user_home }}/.asdf"
     PATH: "/usr/local/bin:/{{ sliver_user_home }}/.asdf/shims:/usr/bin:/bin"
 
+- name: Ensure .sliver-client/configs directory exists
+  ansible.builtin.file:
+    path: "{{ sliver_user_home }}/.sliver-client/configs"
+    state: directory
+    owner: "{{ sliver_username }}"
+    group: "{{ sliver_usergroup }}"
+    mode: '0755'
+  become: true
+
 - name: Generate operator config
   ansible.builtin.shell:
     cmd: |
       {{ sliver_install_path }}/sliver-server operator --name {{ sliver_username }} \
       --lhost localhost \
       --permissions all \
-      --save "{{ sliver_user_home }}/.sliver-client/configs"
-      chown -R {{ sliver_username }}:"{{ sliver_usergroup }}" "{{ sliver_install_path }}/sliver-client"
+      --save {{ sliver_user_home }}/.sliver-client/configs
   become: true
   become_user: "{{ sliver_username }}"
   args:
     executable: /bin/bash
   changed_when: "'configs saved' in result.stdout"
   register: result
+
+- name: Set ownership of sliver-client binary
+  ansible.builtin.file:
+    path: "{{ sliver_install_path }}/sliver-client"
+    owner: "{{ sliver_username }}"
+    group: "{{ sliver_usergroup }}"
+  become: true

--- a/roles/ttpforge/molecule/default/create.yml
+++ b/roles/ttpforge/molecule/default/create.yml
@@ -1,0 +1,41 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    molecule_labels:
+      owner: molecule
+  tasks:
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: lookup('env', 'HOME') | length > 0
+
+    - name: Create molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
+        image: "{{ item.image }}"
+        command: "{{ item.command | default('') }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
+      register: server
+      loop: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      delay: 1
+      loop: "{{ server.results }}"

--- a/roles/ttpforge/molecule/default/destroy.yml
+++ b/roles/ttpforge/molecule/default/destroy.yml
@@ -1,0 +1,14 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+      when: molecule_yml.platforms is defined


### PR DESCRIPTION
**Key Changes:**

- Improved creation and ownership setup for Sliver operator config.
- Enhanced Molecule tests for verification and idempotency.
- Verified presence and permissions of generated config and binaries.

**Added:**

- Ensure `.sliver-client/configs` dir creation with correct owner/perm.
- Molecule verify: set `sliver_user_home` var for test context.
- Verify `sliver-client` exists and is executable in Molecule tests.
- Verify operator config exists and is non-empty in correct location.

**Changed:**

- Generate operator config directly in `.sliver-client/configs`.
- Set `sliver-client` binary ownership after config generation.
- Improved idempotency and correct context for config dir tasks.
- Sudoers check now fails when missing for non-root users.

**Removed:**

- Redundant or unclear privilege escalation during config creation.