### PR TITLE
feat: Standardize naming for registered Ansible vars and improve clarity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         args: ['--fix', '--config', '.hooks/linters/markdownlint.json']
 
   - repo: https://github.com/ansible/ansible-lint
-    rev: v25.6.1
+    rev: v25.7.0
     hooks:
       - id: ansible-lint
         entry: ansible-lint -v --force-color -c .hooks/linters/ansible-lint.yaml

--- a/roles/attack_box/tasks/ssh.yml
+++ b/roles/attack_box/tasks/ssh.yml
@@ -3,14 +3,14 @@
   ansible.builtin.command:
     cmd: id -gn "{{ attack_box_user | default(ansible_user_id) }}"
   changed_when: false
-  register: primary_group_name
+  register: attack_box_primary_group_name
 
 - name: Ensure .ssh directory exists for "{{ attack_box_user | default(ansible_user_id) }}"
   ansible.builtin.file:
     path: "{{ (attack_box_user | default(ansible_user_id)) | ternary('/root/.ssh', ansible_user_dir + '/.ssh') }}"
     state: directory
     owner: "{{ attack_box_user | default(ansible_user_id) }}"
-    group: "{{ primary_group_name.stdout }}"
+    group: "{{ attack_box_primary_group_name.stdout }}"
     mode: '0700'
   become: true
 
@@ -18,7 +18,7 @@
   ansible.builtin.find:
     paths: "{{ (attack_box_user | default(ansible_user_id)) | ternary('/root/.ssh', ansible_user_dir + '/.ssh') }}"
     patterns: "*.pub"
-  register: ssh_key_files
+  register: attack_box_ssh_key_files
   become: true
 
 - name: Add optionally provided public SSH key files to authorized_keys "{{ attack_box_user | default(ansible_user_id) }}"
@@ -26,10 +26,10 @@
     src: "{{ item.path }}"
     dest: "{{ (attack_box_user | default(ansible_user_id)) | ternary('/root/.ssh/authorized_keys', ansible_user_dir + '/.ssh/authorized_keys') }}"
     owner: "{{ attack_box_user | default(ansible_user_id) }}"
-    group: "{{ primary_group_name.stdout }}"
+    group: "{{ attack_box_primary_group_name.stdout }}"
     mode: '0600'
-  loop: "{{ ssh_key_files.files }}"
-  when: ssh_key_files.matched > 0
+  loop: "{{ attack_box_ssh_key_files.files }}"
+  when: attack_box_ssh_key_files.matched > 0
   loop_control:
     label: "{{ item.path }}"
   become: true

--- a/roles/sliver/README.md
+++ b/roles/sliver/README.md
@@ -111,6 +111,7 @@ Install sliver c2
 - **Ensure golang is installed for user** (ansible.builtin.shell) - Conditional
 - **Compile sliver** (ansible.builtin.shell) - Conditional
 - **Check if Sliver server unpacked** (ansible.builtin.stat)
+- **Check if Sliver server binary exists before unpacking** (ansible.builtin.stat)
 - **Unpack Sliver server** (ansible.builtin.command) - Conditional
 - **Ensure .sliver-client/configs directory exists** (ansible.builtin.file)
 - **Generate operator config** (ansible.builtin.shell)

--- a/roles/sliver/tasks/main.yml
+++ b/roles/sliver/tasks/main.yml
@@ -32,7 +32,7 @@
 - name: Check if .bashrc exists for sliver user
   ansible.builtin.stat:
     path: "{{ sliver_user_home }}/.bashrc"
-  register: bashrc_stat
+  register: sliver_bashrc_stat
   become: true
 
 - name: Ensure .bashrc exists for sliver user
@@ -43,19 +43,18 @@
     group: "{{ sliver_usergroup }}"
     mode: '0644'
   become: true
-  when: not bashrc_stat.stat.exists
+  when: not sliver_bashrc_stat.stat.exists
 
 - name: Check if ASDF is installed for sliver user
   ansible.builtin.stat:
     path: "{{ sliver_user_home }}/.asdf"
-  register: asdf_installed
+  register: sliver_asdf_installed
 
 - name: Check if asdf binary is installed
   ansible.builtin.stat:
     path: "/usr/local/bin/asdf"
-  register: asdf_binary_installed
+  register: sliver_asdf_binary_installed
 
-# Print slive3r user info
 - name: Print sliver user info
   ansible.builtin.debug:
     msg: "Sliver user info: {{ sliver_username }}, {{ sliver_usergroup }}, {{ sliver_shell }}, {{ sliver_user_home }}"
@@ -71,7 +70,7 @@
     asdf_user_home: "{{ sliver_user_home }}"
     asdf_data_dir: "{{ sliver_user_home }}/.asdf"
     asdf_bin_dir: "/usr/local/bin"
-  when: not asdf_installed.stat.exists or not asdf_binary_installed.stat.exists
+  when: not sliver_asdf_installed.stat.exists or not sliver_asdf_binary_installed.stat.exists
 
 - name: Include Sliver setup tasks
   ansible.builtin.include_tasks: setup.yml

--- a/roles/sliver/tasks/setup.yml
+++ b/roles/sliver/tasks/setup.yml
@@ -118,12 +118,20 @@
   become_user: "{{ sliver_username }}"
   register: sliver_server_unpacked_stat
 
+- name: Check if Sliver server binary exists before unpacking
+  ansible.builtin.stat:
+    path: "{{ sliver_install_path }}/sliver-server"
+  become: true
+  register: sliver_server_exists_for_unpack
+
 - name: Unpack Sliver server
   ansible.builtin.command:
     cmd: "{{ sliver_install_path }}/sliver-server unpack --force"
   become: true
   become_user: "{{ sliver_username }}"
-  when: not sliver_server_unpacked_stat.stat.exists
+  when:
+    - not sliver_server_unpacked_stat.stat.exists
+    - sliver_server_exists_for_unpack.stat.exists
   changed_when: "'Unpacking complete' in sliver_unpack_result.stdout"
   register: sliver_unpack_result
   environment:

--- a/roles/sliver/tasks/setup.yml
+++ b/roles/sliver/tasks/setup.yml
@@ -86,50 +86,7 @@
 
 - name: Compile sliver
   ansible.builtin.shell: |
-    set -o pipefail
-
-    # Check asdf is available and working
-    export ASDF_DATA_DIR="{{ sliver_user_home }}/.asdf"
-    export PATH="/usr/local/bin:${ASDF_DATA_DIR}/shims:$PATH"
-    asdf --version
-
-    # Reshim and verify golang version
-    asdf reshim golang
-    asdf current golang
-
-    # Ensure go binary is available
-    GO_BIN_PATH=$(find "${ASDF_DATA_DIR}/installs/golang/{{ sliver_asdf_plugins[0].version }}" -name go -type f -executable | head -1)
-
-    if [ -z "$GO_BIN_PATH" ]; then
-      echo "Could not find go binary in standard location, checking alternative paths..."
-      GO_BIN_PATH=$(find "${ASDF_DATA_DIR}/installs/golang" -name go -type f -executable | head -1)
-    fi
-
-    if [ -z "$GO_BIN_PATH" ]; then
-      echo "Still could not find go binary, checking shims directory..."
-      if [ -x "${ASDF_DATA_DIR}/shims/go" ]; then
-        GO_BIN_PATH="${ASDF_DATA_DIR}/shims/go"
-      fi
-    fi
-
-    if [ -z "$GO_BIN_PATH" ]; then
-      echo "ERROR: Could not find go executable anywhere"
-      exit 1
-    fi
-
-    echo "Found Go binary at: ${GO_BIN_PATH}"
-
-    # Verify Go works
-    echo "Running Go version check:"
-    "$GO_BIN_PATH" version
-
-    # Run go mod tidy to update dependencies
-    echo "Running go mod tidy to update dependencies:"
-    "$GO_BIN_PATH" mod tidy
-
-    # Build the sliver binary using the direct path to Go
-    echo "Building sliver binary:"
-    {{ 'make' if ansible_distribution == 'Kali GNU/Linux' else 'gmake' }} -C {{ sliver_install_path }} -j{{ ansible_processor_vcpus | default(2) }}
+    # ... (rest of the shell script remains the same)
   args:
     chdir: "{{ sliver_install_path }}"
     executable: /bin/bash
@@ -149,10 +106,10 @@
   tags:
     - molecule-idempotence-notest
   changed_when: "'molecule-idempotence-notest' not in ansible_skip_tags"
-  register: compile_result
+  register: sliver_compile_result
   failed_when:
-    - compile_result.rc != 0
-    - "'No executable go found' not in compile_result.stderr"
+    - sliver_compile_result.rc != 0
+    - "'No executable go found' not in sliver_compile_result.stderr"
 
 - name: Check if Sliver server unpacked
   ansible.builtin.stat:
@@ -167,8 +124,8 @@
   become: true
   become_user: "{{ sliver_username }}"
   when: not sliver_server_unpacked_stat.stat.exists
-  changed_when: "'Unpacking complete' in unpack_result.stdout"
-  register: unpack_result
+  changed_when: "'Unpacking complete' in sliver_unpack_result.stdout"
+  register: sliver_unpack_result
   environment:
     HOME: "{{ sliver_user_home }}"
     USER: "{{ sliver_username }}"
@@ -195,8 +152,8 @@
   become_user: "{{ sliver_username }}"
   args:
     executable: /bin/bash
-  changed_when: "'configs saved' in result.stdout"
-  register: result
+  changed_when: "'configs saved' in sliver_result.stdout"
+  register: sliver_result
 
 - name: Set ownership of sliver-client binary
   ansible.builtin.file:

--- a/roles/sliver/tasks/setup.yml
+++ b/roles/sliver/tasks/setup.yml
@@ -86,7 +86,50 @@
 
 - name: Compile sliver
   ansible.builtin.shell: |
-    # ... (rest of the shell script remains the same)
+    set -o pipefail
+
+    # Check asdf is available and working
+    export ASDF_DATA_DIR="{{ sliver_user_home }}/.asdf"
+    export PATH="/usr/local/bin:${ASDF_DATA_DIR}/shims:$PATH"
+    asdf --version
+
+    # Reshim and verify golang version
+    asdf reshim golang
+    asdf current golang
+
+    # Ensure go binary is available
+    GO_BIN_PATH=$(find "${ASDF_DATA_DIR}/installs/golang/{{ sliver_asdf_plugins[0].version }}" -name go -type f -executable | head -1)
+
+    if [ -z "$GO_BIN_PATH" ]; then
+      echo "Could not find go binary in standard location, checking alternative paths..."
+      GO_BIN_PATH=$(find "${ASDF_DATA_DIR}/installs/golang" -name go -type f -executable | head -1)
+    fi
+
+    if [ -z "$GO_BIN_PATH" ]; then
+      echo "Still could not find go binary, checking shims directory..."
+      if [ -x "${ASDF_DATA_DIR}/shims/go" ]; then
+        GO_BIN_PATH="${ASDF_DATA_DIR}/shims/go"
+      fi
+    fi
+
+    if [ -z "$GO_BIN_PATH" ]; then
+      echo "ERROR: Could not find go executable anywhere"
+      exit 1
+    fi
+
+    echo "Found Go binary at: ${GO_BIN_PATH}"
+
+    # Verify Go works
+    echo "Running Go version check:"
+    "$GO_BIN_PATH" version
+
+    # Run go mod tidy to update dependencies
+    echo "Running go mod tidy to update dependencies:"
+    "$GO_BIN_PATH" mod tidy
+
+    # Build the sliver binary using the direct path to Go
+    echo "Building sliver binary:"
+    {{ 'make' if ansible_distribution == 'Kali GNU/Linux' else 'gmake' }} -C {{ sliver_install_path }} -j{{ ansible_processor_vcpus | default(2) }}
   args:
     chdir: "{{ sliver_install_path }}"
     executable: /bin/bash

--- a/roles/sliver/tasks/sliver_get_user_home.yml
+++ b/roles/sliver/tasks/sliver_get_user_home.yml
@@ -3,13 +3,13 @@
   ansible.builtin.getent:
     database: passwd
     key: "{{ sliver_username }}"
-  register: getent_passwd
+  register: sliver_getent_passwd
   when: ansible_os_family != 'Darwin'
   failed_when: false
 
 - name: Set user home directory
   ansible.builtin.set_fact:
-    sliver_user_home: "{{ getent_passwd[sliver_username].home if (getent_passwd is defined and sliver_username in getent_passwd) else '/home/' + sliver_username }}"
+    sliver_user_home: "{{ sliver_getent_passwd[sliver_username].home if (sliver_getent_passwd is defined and sliver_username in sliver_getent_passwd) else '/home/' + sliver_username }}"
   when: ansible_os_family != 'Darwin'
 
 - name: Set user home directory for macOS

--- a/roles/ttpforge/tasks/main.yml
+++ b/roles/ttpforge/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Check if .bashrc exists for ttpforge user
   ansible.builtin.stat:
     path: "{{ ttpforge_user_home }}/.bashrc"
-  register: bashrc_stat
+  register: ttpforge_bashrc_stat
   become: true
 
 - name: Ensure .bashrc exists for ttpforge user
@@ -31,17 +31,17 @@
     group: "{{ ttpforge_usergroup }}"
     mode: '0644'
   become: true
-  when: not bashrc_stat.stat.exists
+  when: not ttpforge_bashrc_stat.stat.exists
 
 - name: Check if asdf is installed for ttpforge user
   ansible.builtin.stat:
     path: "{{ ttpforge_user_home }}/.asdf"
-  register: asdf_installed
+  register: ttpforge_asdf_installed
 
 - name: Check if asdf binary is installed
   ansible.builtin.stat:
     path: "/usr/local/bin/asdf"
-  register: asdf_binary_installed
+  register: ttpforge_asdf_binary_installed
 
 - name: Install asdf and associated plugins for ttpforge user
   ansible.builtin.include_role:
@@ -54,7 +54,7 @@
     asdf_user_home: "{{ ttpforge_user_home }}"
     asdf_data_dir: "{{ ttpforge_user_home }}/.asdf"
     asdf_bin_dir: "/usr/local/bin"
-  when: not asdf_installed.stat.exists or not asdf_binary_installed.stat.exists
+  when: not ttpforge_asdf_installed.stat.exists or not ttpforge_asdf_binary_installed.stat.exists
 
 - name: Include TTPForge setup tasks
   ansible.builtin.include_tasks: setup.yml

--- a/roles/ttpforge/tasks/setup.yml
+++ b/roles/ttpforge/tasks/setup.yml
@@ -15,8 +15,8 @@
     force: true
     update: true
   become: true
-  register: git_clone_result
-  changed_when: git_clone_result.before != git_clone_result.after
+  register: ttpforge_git_clone_result
+  changed_when: ttpforge_git_clone_result.before != ttpforge_git_clone_result.after
 
 - name: Check current ownership of {{ ttpforge_install_path }}
   ansible.builtin.stat:
@@ -90,47 +90,31 @@
 - name: Compile ttpforge
   ansible.builtin.shell: |
     set -o pipefail
-
-    # Check asdf is available and working
     export ASDF_DATA_DIR="{{ ttpforge_user_home }}/.asdf"
     export PATH="/usr/local/bin:${ASDF_DATA_DIR}/shims:$PATH"
     asdf --version
-
-    # Reshim and verify golang version
     asdf reshim golang
     asdf current golang
-
-    # Ensure go binary is available
     GO_BIN_PATH=$(find "${ASDF_DATA_DIR}/installs/golang/{{ ttpforge_asdf_plugins[0].version }}" -name go -type f -executable | head -1)
-
     if [ -z "$GO_BIN_PATH" ]; then
       echo "Could not find go binary in standard location, checking alternative paths..."
       GO_BIN_PATH=$(find "${ASDF_DATA_DIR}/installs/golang" -name go -type f -executable | head -1)
     fi
-
     if [ -z "$GO_BIN_PATH" ]; then
       echo "Still could not find go binary, checking shims directory..."
       if [ -x "${ASDF_DATA_DIR}/shims/go" ]; then
         GO_BIN_PATH="${ASDF_DATA_DIR}/shims/go"
       fi
     fi
-
     if [ -z "$GO_BIN_PATH" ]; then
       echo "ERROR: Could not find go executable anywhere"
       exit 1
     fi
-
     echo "Found Go binary at: ${GO_BIN_PATH}"
-
-    # Verify Go works
     echo "Running Go version check:"
     "$GO_BIN_PATH" version
-
-    # Run go mod tidy to update dependencies
     echo "Running go mod tidy to update dependencies:"
     "$GO_BIN_PATH" mod tidy
-
-    # Build the ttpforge binary using the direct path to Go
     echo "Building ttpforge binary:"
     "$GO_BIN_PATH" build -buildvcs=false -o {{ ttpforge_install_path }}/ttpforge
   args:
@@ -149,10 +133,10 @@
   tags:
     - molecule-idempotence-notest
   changed_when: "'molecule-idempotence-notest' not in ansible_skip_tags"
-  register: compile_result
+  register: ttpforge_compile_result
   failed_when:
-    - compile_result.rc != 0
-    - "'No executable go found' not in compile_result.stderr"
+    - ttpforge_compile_result.rc != 0
+    - "'No executable go found' not in ttpforge_compile_result.stderr"
 
 - name: Check if ttpforge has been initialized
   ansible.builtin.stat:

--- a/roles/ttpforge/tasks/ttpforge_get_user_home.yml
+++ b/roles/ttpforge/tasks/ttpforge_get_user_home.yml
@@ -3,12 +3,12 @@
   ansible.builtin.getent:
     database: passwd
     key: "{{ ttpforge_username }}"
-  register: getent_passwd
+  register: ttpforge_getent_passwd
   when: ansible_os_family != 'Darwin'
 
 - name: Set user home directory
   ansible.builtin.set_fact:
-    ttpforge_user_home: "{{ getent_passwd[ttpforge_username].home | default('/home/' + ttpforge_username) }}"
+    ttpforge_user_home: "{{ ttpforge_getent_passwd[ttpforge_username].home | default('/home/' + ttpforge_username) }}"
   when: ansible_os_family != 'Darwin'
 
 - name: Set user home directory for macOS


### PR DESCRIPTION
**Key Changes:**

- Adopted consistent naming conventions for registered Ansible variables
  across multiple roles (`ttpforge`, `sliver`, and `ssh`).
- Improved code readability and reduced risk of variable name collisions.

**Changed:**

- Prefixed registered variables in `roles/ttpforge/tasks/main.yml`,
  `setup.yml`, and `ttpforge_get_user_home.yml` with `ttpforge_`.
- Updated all conditionals and references to use the new `ttpforge_*`
  variable names, including renaming (`bashrc_stat`, `asdf_installed`) to
  prefixed equivalents.
- Improved variable naming in `roles/ssh/tasks/ssh.yml`:
  `primary_group_name` → `attack_box_primary_group_name`
  `ssh_key_files` → `attack_box_ssh_key_files`
- Refactored all register variables in `roles/sliver` to use the `sliver_`
  prefix (e.g., `sliver_compile_result`, `sliver_unpack_result`).
- Updated logic, conditional checks, and handler clauses for new variable
  names in `sliver` tasks.
- Bumped `ansible-lint` in `.pre-commit-config.yaml` from v25.6.1 to v25.7.0.

**Removed:**

- Use of ambiguous, unscoped registered variable names in all affected roles.