### PR TITLE
feat: Improve Renovate config, pre-commit, deps, and asdf plugin automation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,84 +1,86 @@
 {
-  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  gitAuthor: 'l50-renovate-bot <153877091+l50-renovate-bot[bot]@users.noreply.github.com>',
-  extends: [
-    'config:recommended',
-    'docker:enableMajor',
-    ':disableRateLimiting',
-    ':dependencyDashboard',
-    ':semanticCommits',
-    ':enablePreCommit',
-    ':automergeDigest',
-    'helpers:pinGitHubActionDigests',
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "gitAuthor": "l50-renovate-bot <153877091+l50-renovate-bot[bot]@users.noreply.github.com>",
+  "extends": [
+    "config:recommended",
+    "docker:enableMajor",
+    ":disableRateLimiting",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":enablePreCommit",
+    ":automergeDigest",
+    "helpers:pinGitHubActionDigests"
   ],
-  dependencyDashboardLabels: [
-    'renovate-dashboard',
+  "dependencyDashboardLabels": [
+    "renovate-dashboard"
   ],
-  dependencyDashboardTitle: 'Renovate Dashboard 🤖',
-  suppressNotifications: [
-    'prIgnoreNotification',
+  "dependencyDashboardTitle": "Renovate Dashboard 🤖",
+  "suppressNotifications": [
+    "prIgnoreNotification"
   ],
-  rebaseWhen: 'conflicted',
-  commitBodyTable: true,
-  labels: [
-    'renovate',
+  "rebaseWhen": "conflicted",
+  "commitBodyTable": true,
+  "labels": [
+    "renovate"
   ],
-  'pre-commit': {
-    enabled: true,
+  "pre-commit": {
+    "enabled": true
   },
-  packageRules: [
+  "packageRules": [
     {
-      description: 'Auto merge Galaxy dependencies',
-      matchDatasources: [
-        'galaxy',
+      "description": "Auto merge Galaxy dependencies",
+      "matchManagers": [
+        "ansible-galaxy"
       ],
-      automerge: true,
-      automergeType: 'pr',
-      matchUpdateTypes: [
-        'digest',
-      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ]
     },
     {
-      description: 'Auto-merge GitHub Actions',
-      matchManagers: [
-        'github-actions',
+      "description": "Auto-merge GitHub Actions",
+      "matchManagers": [
+        "github-actions"
       ],
-      matchDatasources: [
-        'github-tags',
-      ],
-      automerge: true,
-      automergeType: 'pr',
-      matchUpdateTypes: [
-        'minor',
-        'patch',
-      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ]
     },
     {
-      description: 'Group Ansible Galaxy dependencies',
-      matchManagers: [
-        'ansible-galaxy',
+      "description": "Group Ansible Galaxy dependencies",
+      "matchManagers": [
+        "ansible-galaxy"
       ],
-      groupName: 'ansible-dependencies',
+      "groupName": "ansible-dependencies"
     },
+    {
+      "description": "Auto-merge asdf plugin updates",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ]
+    }
   ],
-  ansible: {
-    managerFilePatterns: [
-      '/^requirements\\.yml$/',
-      '/^roles/[^/]+/meta/main\\.yml$/',
-      '/^galaxy\\.yml$/',
-    ],
-  },
-  customManagers: [
+  "customManagers": [
     {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/(^|/)requirements\\.ya?ml$/',
-        '/(^|/)galaxy\\.ya?ml$/',
+      "customType": "regex",
+      "description": "Update asdf plugin versions in Ansible roles",
+      "fileMatch": [
+        "^roles/.*/defaults/main\\.yml$"
       ],
-      matchStrings: [
-        'name: (?<depName>[^\\s]+)\\n\\s+src: (?<packageName>[^\\s]+)\\n\\s+version: (?<currentValue>[^\\s]+)',
-      ],
-      datasourceTemplate: 'git-tags',
-    },
-  ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[\\w-]+)(?: packageName=(?<packageName>[\\w-/]+))?(?: extractVersion=(?<extractVersion>[^\\s]+))?\\s*\\n\\s*- name:\\s*[\\w-]+\\s*\\n\\s*version:\\s*\"(?<currentValue>[0-9.]+)\""
+      ]
+    }
+  ]
 }

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Renovate
         uses: renovatebot/github-action@7876d7a812254599d262d62b6b2c2706018258a2 # v43.0.10
         env:
-          LOG_LEVEL: "${{ inputs.logLevel || 'debug' }}"
+          LOG_LEVEL: "${{ inputs.logLevel || 'info' }}"
           RENOVATE_AUTODISCOVER: true
           RENOVATE_AUTODISCOVER_FILTER: "${{ github.repository }}"
           RENOVATE_DRY_RUN: "${{ inputs.dryRun }}"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ changelogs/.plugin-cache.yaml
 .task/
 .ansible
 *.tar.gz
+*.log

--- a/.hooks/requirements.txt
+++ b/.hooks/requirements.txt
@@ -1,7 +1,7 @@
-ansible-core
-docker
+ansible-core==2.19.1
+docker==7.1.0
 docsible==0.7.25
-molecule
-molecule-docker
-molecule-plugins[docker]
-pre-commit
+molecule==25.7.0
+molecule-docker==2.1.0
+molecule-plugins[docker]==25.8.12
+pre-commit==4.3.0

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,6 +1,6 @@
 # Ansible Collection Release Process
 
-This document outlines the process for creating new releases of the Ansible collection.
+This document outlines the process for creating new releases of this Ansible collection.
 
 ## Prerequisites
 
@@ -18,7 +18,7 @@ This document outlines the process for creating new releases of the Ansible coll
 
 ## Pre-Release Tasks
 
-Before creating a release, you should perform these preparation steps:
+Before creating a release, perform these preparation steps:
 
 1. **Run Molecule Tests**
 
@@ -61,7 +61,7 @@ Before creating a release, you should perform these preparation steps:
    task -y ansible:lint-ansible
    ```
 
-   This runs ansible-lint with the configuration file at .hooks/linters/ansible-lint.yaml.
+   This runs ansible-lint with the configuration file at `.hooks/linters/ansible-lint.yaml`.
 
 1. **Update Collection Dependencies and Versions**
 
@@ -108,7 +108,7 @@ You can work with the changelog in two ways:
 
 ```bash
 export TASK_X_REMOTE_TASKFILES=1
-NEXT_VERSION=1.0.0 task ansible:gen-changelog
+NEXT_VERSION=$NEXT_VERSION task -y ansible:gen-changelog
 ```
 
 This command will run all the necessary steps (linting and release generation).
@@ -126,7 +126,7 @@ Then generate the release:
 
 ```bash
 export TASK_X_REMOTE_TASKFILES=1
-NEXT_VERSION=1.0.0 task -y ansible:changelog-release
+NEXT_VERSION=$NEXT_VERSION task -y ansible:changelog-release
 ```
 
 **Required Variables:**

--- a/roles/sliver/defaults/main.yml
+++ b/roles/sliver/defaults/main.yml
@@ -6,6 +6,7 @@ sliver_username: "sliver"
 sliver_usergroup: "sliver"
 sliver_shell: "{% if ansible_os_family == 'Darwin' %}/bin/zsh{% else %}/bin/bash{% endif %}"
 sliver_asdf_plugins:
+  # renovate: datasource=github-tags depName=golang packageName=golang/go extractVersion=^go(?<version>.*)$
   - name: golang
     version: "1.22.2"
     scope: "global"

--- a/roles/ttpforge/defaults/main.yml
+++ b/roles/ttpforge/defaults/main.yml
@@ -4,9 +4,11 @@ ttpforge_username: "{% if ansible_os_family == 'Darwin' %}{{ ansible_user_id }}{
 ttpforge_usergroup: "{% if ansible_os_family == 'Darwin' %}staff{% elif ansible_os_family == 'Debian' %}{{ ansible_user_id }}{% elif ansible_os_family == 'RedHat' %}{{ ansible_user_id }}{% else %}{{ ansible_distribution | lower }}{% endif %}"
 ttpforge_shell: "{% if ansible_os_family == 'Darwin' %}/bin/zsh{% else %}/bin/bash{% endif %}"
 ttpforge_asdf_plugins:
+  # renovate: datasource=github-tags depName=golang packageName=golang/go extractVersion=^go(?<version>.*)$
   - name: golang
     version: "1.24.0"
     scope: "global"
+  # renovate: datasource=github-tags depName=python packageName=python/cpython extractVersion=^v(?<version>.*)$
   - name: python
     version: "3.13.1"
     scope: "global"


### PR DESCRIPTION
**Key Changes:**

- Refactored `.github/renovate.json5` to modern JSON syntax and enhanced rules.
- Improved Renovate automation for asdf plugin updates in Ansible roles.
- Added precise Ansible requirements and pip dependency versions.
- Lowered default Renovate log level for CI workflow.
- Improved `.pre-commit-config.yaml` with auto-arch diagram generator.
- Expanded `.gitignore` cleanup.

**Added:**

- Renovate `customManagers` and match strings for asdf plugins.
- Pre-commit hook: Update Architecture Diagram (runs on infra changes).
- `# renovate:` comments for asdf plugins in Ansible role defaults.
- `.gitignore` rule for `*.log` files.

**Changed:**

- Migrated Renovate config to full JSON with string keys.
- Ansible, molecule, docker, and pre-commit now version-pinned.
- Default workflow Renovate log level from `debug` to `info`.
- Refined docs/release steps for clarity and consistency.

**Removed:**

- Support for unversioned dependencies in `.hooks/requirements.txt`.
- Legacy Galaxy/datasource handling in package rules (uses matchManagers).