### PR TITLE
feat: Auto-generate Ansible architecture diagrams in README

### DIFF
--- a/.hooks/gen-arch-diagram.py
+++ b/.hooks/gen-arch-diagram.py
@@ -63,7 +63,7 @@ def generate_mermaid(structure):
 
     # Add roles
     if structure['roles']:
-        lines.append("    Collection --> Roles[🎭 Roles]")
+        lines.append("    Collection --> Roles[⚙️ Roles]")
         for i, role in enumerate(structure['roles']):
             role_label = role['name']
             if role['has_molecule']:

--- a/.hooks/gen-arch-diagram.py
+++ b/.hooks/gen-arch-diagram.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Ansible Collection Mermaid Diagram Generator Pre-commit Hook
+
+Generates a Mermaid diagram from an Ansible collection structure
+and updates repo README.
+"""
+
+from pathlib import Path
+import sys
+import re
+
+class AnsibleCollectionAnalyzer:
+    def __init__(self, collection_path: str):
+        self.collection_path = Path(collection_path)
+        self.structure = {
+            'roles': [],
+            'plugins': [],
+            'playbooks': []
+        }
+
+    def analyze(self):
+        """Analyze the Ansible collection structure"""
+        # Analyze roles
+        roles_path = self.collection_path / 'roles'
+        if roles_path.exists():
+            for role_dir in roles_path.iterdir():
+                if role_dir.is_dir() and not role_dir.name.startswith('.'):
+                    self.structure['roles'].append({
+                        'name': role_dir.name,
+                        'has_molecule': (role_dir / 'molecule').exists()
+                    })
+
+        # Analyze plugins
+        plugins_path = self.collection_path / 'plugins' / 'modules'
+        if plugins_path.exists():
+            for plugin_file in plugins_path.glob('*.py'):
+                if not plugin_file.name.startswith('__'):
+                    self.structure['plugins'].append(plugin_file.stem)
+
+        # Analyze playbooks
+        playbooks_path = self.collection_path / 'playbooks'
+        if playbooks_path.exists():
+            for item in playbooks_path.iterdir():
+                if item.is_dir() and not item.name.startswith('.'):
+                    self.structure['playbooks'].append({
+                        'name': item.name,
+                        'has_molecule': (item / 'molecule').exists()
+                    })
+
+        return self.structure
+
+def generate_mermaid(structure):
+    """Generate Mermaid diagram"""
+    lines = ["```mermaid", "graph TD"]
+    lines.append("    Collection[Ansible Collection]")
+
+    # Add plugins
+    if structure['plugins']:
+        lines.append("    Collection --> Plugins[🔌 Plugins]")
+        for i, plugin in enumerate(structure['plugins']):
+            lines.append(f"    Plugins --> P{i}[{plugin}]")
+
+    # Add roles
+    if structure['roles']:
+        lines.append("    Collection --> Roles[🎭 Roles]")
+        for i, role in enumerate(structure['roles']):
+            role_label = role['name']
+            if role['has_molecule']:
+                role_label += " 🧪"
+            lines.append(f"    Roles --> R{i}[{role_label}]")
+
+    # Add playbooks
+    if structure['playbooks']:
+        lines.append("    Collection --> Playbooks[📚 Playbooks]")
+        for i, playbook in enumerate(structure['playbooks']):
+            pb_label = playbook['name']
+            if playbook['has_molecule']:
+                pb_label += " 🧪"
+            lines.append(f"    Playbooks --> PB{i}[{pb_label}]")
+
+    lines.append("```")
+    return '\n'.join(lines)
+
+def update_readme(mermaid_content):
+    """Update README.md with the generated Mermaid diagram"""
+    readme_path = Path('README.md')
+
+    if not readme_path.exists():
+        print("❌ README.md not found")
+        return False
+
+    readme_content = readme_path.read_text()
+
+    # Define markers for the architecture section
+    start_marker = "## Architecture Diagram"
+    end_marker = "## Requirements"  # The next section after Architecture Diagram
+
+    # Find the start and end positions
+    start_pos = readme_content.find(start_marker)
+    if start_pos == -1:
+        print("❌ Could not find '## Architecture Diagram' section in README.md")
+        return False
+
+    end_pos = readme_content.find(end_marker, start_pos)
+    if end_pos == -1:
+        # If we can't find the next section, look for the next ## heading
+        next_section_pattern = re.compile(r'\n## (?!Architecture Diagram)')
+        match = next_section_pattern.search(readme_content, start_pos + len(start_marker))
+        if match:
+            end_pos = match.start() + 1  # +1 to keep the newline before the next section
+        else:
+            print("❌ Could not find the end of the Architecture Diagram section")
+            return False
+
+    # Build the new architecture section
+    new_section = f"{start_marker}\n\n{mermaid_content}\n\n"
+
+    # Replace the section
+    new_readme = readme_content[:start_pos] + new_section + readme_content[end_pos:]
+
+    # Write back to README
+    readme_path.write_text(new_readme)
+
+    return True
+
+def main():
+    """Main function for pre-commit hook"""
+    # Analyze collection from current directory
+    analyzer = AnsibleCollectionAnalyzer('.')
+    structure = analyzer.analyze()
+
+    # Generate Mermaid diagram
+    mermaid_content = generate_mermaid(structure)
+
+    # Update README.md
+    if update_readme(mermaid_content):
+        print("✅ Architecture diagram updated in README.md")
+        print(f"\nCollection summary:")
+        print(f"  • Roles: {len(structure['roles'])}")
+        print(f"  • Plugins: {len(structure['plugins'])}")
+        print(f"  • Playbooks: {len(structure['playbooks'])}")
+
+        # Stage the README.md file for commit
+        import subprocess
+        try:
+            subprocess.run(['git', 'add', 'README.md'], check=True)
+            print("✅ README.md staged for commit")
+        except subprocess.CalledProcessError:
+            print("⚠️ Could not stage README.md - you may need to add it manually")
+
+        return 0
+    else:
+        print("❌ Failed to update README.md")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,3 +75,12 @@ repos:
         always_run: true
         pass_filenames: false
         stages: [pre-commit]
+
+      - id: update-architecture-diagram
+        name: Update Architecture Diagram
+        entry: python .hooks/gen-arch-diagram.py
+        language: python
+        pass_filenames: false
+        always_run: false
+        files: ^(roles/|plugins/|playbooks/|\.github/workflows/).*
+        additional_dependencies: []

--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@
 This Ansible collection provides offsec tools, configurations, and utilities
 that I employ regularly.
 
+## Architecture Diagram
+
+```mermaid
+graph TD
+    Collection[Ansible Collection]
+    Collection --> Roles[🎭 Roles]
+    Roles --> R0[attack_box 🧪]
+    Roles --> R1[sliver 🧪]
+    Roles --> R2[ttpforge 🧪]
+    Collection --> Playbooks[📚 Playbooks]
+    Playbooks --> PB0[attack_box 🧪]
+    Playbooks --> PB1[sliver 🧪]
+    Playbooks --> PB2[atomic-red-team 🧪]
+    Playbooks --> PB3[ttpforge 🧪]
+```
+
 ## Requirements
 
 - Ansible 2.15 or higher


### PR DESCRIPTION
**Key Changes:**

- Introduced a pre-commit hook to auto-generate and update a Mermaid  
  architecture diagram for the Ansible collection in the README.
- Added a Python script to scan `roles/`, `plugins/`, and `playbooks/`  
  and reflect structure in the diagram.

**Added:**

- `.hooks/gen-arch-diagram.py`: Script to analyze Ansible collection  
  contents, generate a Mermaid diagram, and update the README.
- Pre-commit config entry for the architecture diagram updater, triggering  
  on changes to relevant Ansible directories.

**Changed:**

- `README.md` now contains a Mermaid diagram under an  
  "Architecture Diagram" section, kept in sync with the repo state.
- `.pre-commit-config.yaml` includes the new hook for updating the diagram.