### PR TITLE
docs: update documentation and changelogs for 1.0.5 release

### DIFF
--- a/.github/renovate-bot.json5
+++ b/.github/renovate-bot.json5
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "username": "rosey-bot[bot]",
-  "gitAuthor": "rosey-bot <98030736+rosey-bot[bot]@users.noreply.github.com>",
-  "repositories": ["l50/ansible-collection-arsenal"]
-}

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,1 +1,0 @@
-style '.hooks/linters/mdstyle.rb'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,5 +82,5 @@ repos:
         language: python
         pass_filenames: false
         always_run: false
-        files: ^(roles/|plugins/|playbooks/|\.github/workflows/).*
+        files: ^(roles/|plugins/|playbooks/).*
         additional_dependencies: []

--- a/README.md
+++ b/README.md
@@ -30,10 +30,18 @@ graph TD
 
 ## Installation
 
-Install the Arsenal collection:
+Install latest version of the Arsenal collection:
 
 ```bash
 ansible-galaxy collection install git+https://github.com/l50/ansible-collection-arsenal.git,main
+```
+
+Alternatively, you can build the collection locally and install it from
+the generated tarball:
+
+```bash
+ansible-galaxy collection build --force && \
+  ansible-galaxy collection install l50-arsenal-*.tar.gz -p ~/.ansible/collections --force --pre
 ```
 
 ## Roles
@@ -59,13 +67,30 @@ Include the roles from this collection in your playbook. Here's an example:
 
 ```yaml
 ---
-- name: Provision container
+- name: Provision system
   hosts: localhost
   roles:
     - l50.arsenal.sliver
     - l50.arsenal.ttpforge
     - l50.arsenal.attack_box
 ```
+
+## Development
+
+### Setting Up Development Environment
+
+To set up the development environment and install all required dependencies,
+including docsible for automatic documentation generation:
+
+```bash
+python3 -m pip install -r .hooks/requirements.txt
+```
+
+### Documentation Generation
+
+This project uses [docsible](https://github.com/docsible/docsible) to automatically
+generate documentation for Ansible roles. Documentation is generated automatically
+via pre-commit hooks when changes are made to role files.
 
 ## License
 

--- a/changelogs/CHANGELOG.rst
+++ b/changelogs/CHANGELOG.rst
@@ -1,8 +1,56 @@
 ==============================================
-Arsenal Ansible Collection 1.0.4 Release Notes
+Arsenal Ansible Collection 1.0.5 Release Notes
 ==============================================
 
 .. contents:: Topics
+
+v1.0.5
+======
+
+Added
+-----
+
+- Added SSL certificate environment variables for Go module downloads.
+- Added `.templatesyncignore` file to control template synchronization.
+- Added `area/plugins` label for plugin directory changes.
+- Added `create.yml` and `destroy.yml` to all Molecule test scenarios.
+- Added `go mod tidy` step before compilation in sliver and ttpforge roles.
+- Added alternative local build and install method for the collection in README
+- Added architecture diagram generation with Mermaid for collection visualization.
+- Added comprehensive README documentation for all playbooks.
+- Added custom Docsible template for automated Ansible role documentation.
+- Added development environment setup and documentation generation instructions to README
+- Added markdownlint configuration replacing mdstyle.rb.
+- Added renovate dashboard label configuration.
+- Added template sync workflow for infrastructure file synchronization.
+- Added use of Docsible for automated role documentation to README
+
+Changed
+-------
+
+- Enhanced error handling and fallback mechanisms in Go binary detection.
+- Fixed ASDF installation checks to verify both data directory and binary.
+- Fixed sliver role operator config generation with proper permissions.
+- Fixed ttpforge compilation issues with proper environment variable setup.
+- Fixed user home directory detection for different OS families.
+- Improved ASDF plugin version management with renovate datasource annotations.
+- Improved Molecule test configurations with consistent provisioner settings.
+- Refactored sliver role to use single user configuration instead of user list.
+- Refactored ttpforge role with improved user home directory detection.
+- Simplified playbook configurations removing redundant variable definitions.
+- Standardized shell configuration to use .bashrc instead of .bash_profile.
+- Updated Ansible collection dependencies (amazon.aws to 10.1.1, ansible.windows to 3.2.0, community.docker to 4.7.0, community.general to 11.2.1).
+- Updated GitHub Actions to latest versions (create-github-app-token, checkout, setup-python, cache).
+- Updated Go version to 1.24.4 and Python to 3.13.3 in CI workflows.
+- Updated renovate configuration with improved automerge rules and custom regex managers.
+
+Removed
+-------
+
+- Removed `generate_docs.py` in favor of Docsible documentation generation.
+- Removed `mdstyle.rb` linter configuration file.
+- Removed redundant user creation tasks from playbook converge files.
+- Removed unused `install-sliver.sh.j2` template.
 
 v1.0.4
 ======

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -163,3 +163,46 @@ releases:
       - Removed inline comment about `bash_profile` creation being conditional.
       - Removed old system package.
     release_date: '2025-04-11'
+  1.0.5:
+    changes:
+      added:
+      - Added SSL certificate environment variables for Go module downloads.
+      - Added `.templatesyncignore` file to control template synchronization.
+      - Added `area/plugins` label for plugin directory changes.
+      - Added `create.yml` and `destroy.yml` to all Molecule test scenarios.
+      - Added `go mod tidy` step before compilation in sliver and ttpforge roles.
+      - Added alternative local build and install method for the collection in README
+      - Added architecture diagram generation with Mermaid for collection visualization.
+      - Added comprehensive README documentation for all playbooks.
+      - Added custom Docsible template for automated Ansible role documentation.
+      - Added development environment setup and documentation generation instructions
+        to README
+      - Added markdownlint configuration replacing mdstyle.rb.
+      - Added renovate dashboard label configuration.
+      - Added template sync workflow for infrastructure file synchronization.
+      - Added use of Docsible for automated role documentation to README
+      changed:
+      - Enhanced error handling and fallback mechanisms in Go binary detection.
+      - Fixed ASDF installation checks to verify both data directory and binary.
+      - Fixed sliver role operator config generation with proper permissions.
+      - Fixed ttpforge compilation issues with proper environment variable setup.
+      - Fixed user home directory detection for different OS families.
+      - Improved ASDF plugin version management with renovate datasource annotations.
+      - Improved Molecule test configurations with consistent provisioner settings.
+      - Refactored sliver role to use single user configuration instead of user list.
+      - Refactored ttpforge role with improved user home directory detection.
+      - Simplified playbook configurations removing redundant variable definitions.
+      - Standardized shell configuration to use .bashrc instead of .bash_profile.
+      - Updated Ansible collection dependencies (amazon.aws to 10.1.1, ansible.windows
+        to 3.2.0, community.docker to 4.7.0, community.general to 11.2.1).
+      - Updated GitHub Actions to latest versions (create-github-app-token, checkout,
+        setup-python, cache).
+      - Updated Go version to 1.24.4 and Python to 3.13.3 in CI workflows.
+      - Updated renovate configuration with improved automerge rules and custom regex
+        managers.
+      removed:
+      - Removed `generate_docs.py` in favor of Docsible documentation generation.
+      - Removed `mdstyle.rb` linter configuration file.
+      - Removed redundant user creation tasks from playbook converge files.
+      - Removed unused `install-sliver.sh.j2` template.
+    release_date: '2025-09-04'

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -108,7 +108,7 @@ You can work with the changelog in two ways:
 
 ```bash
 export TASK_X_REMOTE_TASKFILES=1
-NEXT_VERSION=$NEXT_VERSION task -y ansible:gen-changelog
+NEXT_VERSION=x.y.z task -y ansible:gen-changelog
 ```
 
 This command will run all the necessary steps (linting and release generation).

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -107,8 +107,9 @@ You can work with the changelog in two ways:
 #### Option 1: Run the complete changelog process in one command
 
 ```bash
+NEXT_VERSION=x.y.z
 export TASK_X_REMOTE_TASKFILES=1
-NEXT_VERSION=x.y.z task -y ansible:gen-changelog
+NEXT_VERSION=$NEXT_VERSION task -y ansible:gen-changelog
 ```
 
 This command will run all the necessary steps (linting and release generation).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: l50
 name: arsenal
-version: "1.0.4"
+version: "1.0.5"
 readme: README.md
 authors:
   - Jayson Grace <techvomit.net>


### PR DESCRIPTION
**Added:**

- Documented alternative local build and install method for the collection in README
- Added development environment setup and documentation generation instructions to README
- Described use of Docsible for automated role documentation in README
- Documented new features and improvements in CHANGELOG.rst and changelog.yaml for 1.0.5

**Changed:**

- Updated playbook example in README to use "Provision system" instead of "Provision container"
- Clarified installation steps and improved README structure
- Updated example changelog generation command in docs/releases.md for clarity
- Bumped version to 1.0.5 in galaxy.yml and changelogs
- Updated CHANGELOG.rst and changelog.yaml to reflect detailed changes for 1.0.5 release