### PR TITLE
feat: add optional cleanup for sliver role to minimize build artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ that I employ regularly.
 ```mermaid
 graph TD
     Collection[Ansible Collection]
-    Collection --> Roles[🎭 Roles]
+    Collection --> Roles[⚙️ Roles]
     Roles --> R0[attack_box 🧪]
     Roles --> R1[sliver 🧪]
     Roles --> R2[ttpforge 🧪]

--- a/playbooks/sliver/sliver.yml
+++ b/playbooks/sliver/sliver.yml
@@ -5,6 +5,8 @@
     sliver_username: "sliver"
     sliver_usergroup: "sliver"
     sliver_shell: "/bin/bash"
+    # Default to false, override with -e sliver_cleanup=true for production
+    sliver_cleanup: false
   roles:
     - name: Include Sliver role
       role: l50.arsenal.sliver

--- a/roles/sliver/README.md
+++ b/roles/sliver/README.md
@@ -22,6 +22,7 @@ Install sliver c2
 |----------|------|---------|-------------|
 | `sliver_install_path` | str | `/opt/sliver` | No description |
 | `sliver_setup_systemd` | bool | `False` | No description |
+| `sliver_cleanup` | bool | `False` | No description |
 | `sliver_username` | str | `sliver` | No description |
 | `sliver_usergroup` | str | `sliver` | No description |
 | `sliver_shell` | str | `{% if ansible_os_family == 'Darwin' %}/bin/zsh{% else %}/bin/bash{% endif %}` | No description |
@@ -84,6 +85,21 @@ Install sliver c2
 
 ## Tasks
 
+### cleanup.yml
+
+- **Clean up build environment** (block) - Conditional
+- **Check if build artifacts exist** (ansible.builtin.stat)
+- **Remove build artifacts and unnecessary files** (ansible.builtin.shell)
+- **Remove Go build environment** (ansible.builtin.file)
+- **Remove development packages (Debian/Ubuntu)** (ansible.builtin.apt) - Conditional
+- **Remove development packages (RedHat/CentOS)** (ansible.builtin.dnf) - Conditional
+- **Clean package manager cache (Debian/Ubuntu)** (ansible.builtin.apt) - Conditional
+- **Remove apt lists** (ansible.builtin.file) - Conditional
+- **Recreate apt lists directory** (ansible.builtin.file) - Conditional
+- **Clean package manager cache (RedHat/CentOS)** (ansible.builtin.command) - Conditional
+- **Remove dnf cache directory** (ansible.builtin.file) - Conditional
+- **Remove temporary files** (ansible.builtin.shell)
+
 ### main.yml
 
 - **Install required packages for Sliver** (ansible.builtin.include_role)
@@ -98,6 +114,7 @@ Install sliver c2
 - **Install asdf and golang for sliver user** (ansible.builtin.include_role) - Conditional
 - **Include Sliver setup tasks** (ansible.builtin.include_tasks)
 - **Include systemd tasks** (ansible.builtin.include_tasks) - Conditional
+- **Include cleanup tasks** (ansible.builtin.include_tasks) - Conditional
 
 ### setup.yml
 

--- a/roles/sliver/defaults/main.yml
+++ b/roles/sliver/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 sliver_install_path: /opt/sliver
 sliver_setup_systemd: false
+sliver_cleanup: false  # Enable for Docker/container builds to minimize image size
 
 sliver_username: "sliver"
 sliver_usergroup: "sliver"

--- a/roles/sliver/tasks/cleanup.yml
+++ b/roles/sliver/tasks/cleanup.yml
@@ -1,0 +1,103 @@
+---
+- name: Clean up build environment
+  when: sliver_cleanup | bool
+  block:
+    - name: Check if build artifacts exist
+      ansible.builtin.stat:
+        path: "{{ sliver_install_path }}/.git"
+      register: sliver_git_dir
+
+    - name: Remove build artifacts and unnecessary files
+      ansible.builtin.shell: |
+        # Clean up Sliver build artifacts
+        cd {{ sliver_install_path }}
+        find . -name "*.o" -delete 2>/dev/null || true
+        find . -name "*.a" -delete 2>/dev/null || true
+        rm -rf .git test docs .github 2>/dev/null || true
+        rm -rf server/assets/fs/darwin 2>/dev/null || true
+        rm -rf server/assets/fs/windows 2>/dev/null || true
+        rm -rf server/assets/fs/linux 2>/dev/null || true
+
+        # Strip debug symbols from binaries if they exist
+        if [ -f {{ sliver_install_path }}/sliver-server ]; then
+          strip {{ sliver_install_path }}/sliver-server || true
+        fi
+        if [ -f {{ sliver_install_path }}/sliver-client ]; then
+          strip {{ sliver_install_path }}/sliver-client || true
+        fi
+      args:
+        executable: /bin/bash
+      become: true
+      changed_when: sliver_git_dir.stat.exists
+
+    - name: Remove Go build environment
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ sliver_user_home }}/go"
+        - "{{ sliver_user_home }}/.cache/go-build"
+        - "{{ sliver_user_home }}/.asdf"
+      become: true
+
+    - name: Remove development packages (Debian/Ubuntu)
+      ansible.builtin.apt:
+        name: "{{ sliver_debian_packages }}"
+        state: absent
+        autoremove: true
+        autoclean: true
+      when: ansible_os_family == "Debian"
+      become: true
+      failed_when: false
+
+    - name: Remove development packages (RedHat/CentOS)
+      ansible.builtin.dnf:
+        name: "{{ sliver_el_packages }}"
+        state: absent
+        autoremove: true
+      when: ansible_os_family == "RedHat"
+      become: true
+      failed_when: false
+
+    - name: Clean package manager cache (Debian/Ubuntu)
+      ansible.builtin.apt:
+        clean: true
+      when: ansible_os_family == "Debian"
+      become: true
+
+    - name: Remove apt lists
+      ansible.builtin.file:
+        path: /var/lib/apt/lists
+        state: absent
+      when: ansible_os_family == "Debian"
+      become: true
+
+    - name: Recreate apt lists directory
+      ansible.builtin.file:
+        path: /var/lib/apt/lists
+        state: directory
+        mode: '0755'
+      when: ansible_os_family == "Debian"
+      become: true
+
+    - name: Clean package manager cache (RedHat/CentOS)
+      ansible.builtin.command:
+        cmd: dnf clean all
+      when: ansible_os_family == "RedHat"
+      become: true
+      changed_when: true
+
+    - name: Remove dnf cache directory
+      ansible.builtin.file:
+        path: /var/cache/dnf
+        state: absent
+      when: ansible_os_family == "RedHat"
+      become: true
+
+    - name: Remove temporary files
+      ansible.builtin.shell: |
+        rm -rf /tmp/* /var/tmp/* 2>/dev/null || true
+      args:
+        executable: /bin/bash
+      become: true
+      changed_when: false

--- a/roles/sliver/tasks/main.yml
+++ b/roles/sliver/tasks/main.yml
@@ -78,3 +78,7 @@
 - name: Include systemd tasks
   ansible.builtin.include_tasks: systemd.yml
   when: sliver_setup_systemd | bool
+
+- name: Include cleanup tasks
+  ansible.builtin.include_tasks: cleanup.yml
+  when: sliver_cleanup | bool


### PR DESCRIPTION
**Added:**

- Introduced `sliver_cleanup` variable to enable optional cleanup of build artifacts and development dependencies, useful for production or container environments - defaults/main.yml, playbooks/sliver/sliver.yml
- Documented `sliver_cleanup` variable and detailed new cleanup tasks in the Sliver role README
- Added `cleanup.yml` task file to perform removal of build artifacts, Go environment, development packages, and temporary files conditionally
- Included execution of cleanup tasks in main Sliver role task flow, gated on `sliver_cleanup` variable

**Changed:**

- Updated mermaid diagram in main README to use gear emoji for Roles node for visual clarity