### PR TITLE
refactor: restructure and harden sliver container cleanup and package management

### DIFF
--- a/roles/sliver/README.md
+++ b/roles/sliver/README.md
@@ -37,10 +37,17 @@ Install sliver c2
 | `sliver_packages` | dict | `{}` | No description |
 | `sliver_packages.essential` | list | `[]` | No description |
 | `sliver_packages.essential.0` | str | `acl` | No description |
-| `sliver_packages.essential.1` | str | `git` | No description |
-| `sliver_packages.essential.2` | str | `gnupg` | No description |
-| `sliver_packages.essential.3` | str | `unzip` | No description |
-| `sliver_packages.essential.4` | str | `zip` | No description |
+| `sliver_packages.essential.1` | str | `ca-certificates` | No description |
+| `sliver_packages.essential.2` | str | `git` | No description |
+| `sliver_packages.essential.3` | str | `gnupg` | No description |
+| `sliver_packages.essential.4` | str | `libcurl4` | No description |
+| `sliver_packages.essential.5` | str | `libssl3` | No description |
+| `sliver_packages.essential.6` | str | `libxml2` | No description |
+| `sliver_packages.essential.7` | str | `unzip` | No description |
+| `sliver_packages.essential.8` | str | `vim` | No description |
+| `sliver_packages.essential.9` | str | `vim-common` | No description |
+| `sliver_packages.essential.10` | str | `vim-runtime` | No description |
+| `sliver_packages.essential.11` | str | `zip` | No description |
 | `sliver_packages.build_only` | list | `[]` | No description |
 | `sliver_packages.build_only.0` | str | `make` | No description |
 | `sliver_packages.build_only.1` | str | `wget` | No description |
@@ -116,6 +123,12 @@ Install sliver c2
 | `sliver_cleanup_paths.9` | str | `/root/.local` | No description |
 | `sliver_cleanup_paths.10` | str | `/root/.tool-versions` | No description |
 | `sliver_cleanup_paths.11` | str | `/root/.ssh` | No description |
+| `sliver_cleanup_paths.12` | str | `/tmp/*` | No description |
+| `sliver_cleanup_paths.13` | str | `/var/tmp/*` | No description |
+| `sliver_cleanup_paths.14` | str | `/var/cache/debconf` | No description |
+| `sliver_cleanup_paths.15` | str | `/var/lib/systemd/catalog` | No description |
+| `sliver_cleanup_paths.16` | str | `/var/spool/cron` | No description |
+| `sliver_cleanup_paths.17` | str | `/var/spool/mail` | No description |
 | `sliver_mingw_directories` | list | `[]` | No description |
 | `sliver_mingw_directories.0` | str | `/usr/x86_64-w64-mingw32` | No description |
 | `sliver_mingw_directories.1` | str | `/usr/i686-w64-mingw32` | No description |
@@ -147,7 +160,8 @@ Install sliver c2
 ### cleanup.yml
 
 - **Clean up build environment** (block) - Conditional
-- **Hold git package to prevent removal during cleanup** (ansible.builtin.dpkg_selections) - Conditional
+- **Create list of packages to protect** (ansible.builtin.set_fact) - Conditional
+- **Hold runtime and essential packages before cleanup** (ansible.builtin.dpkg_selections) - Conditional
 - **Remove build-time Go installation and caches** (ansible.builtin.file)
 - **Find non-binary files in sliver directory** (ansible.builtin.find)
 - **Remove non-binary files from sliver directory** (ansible.builtin.file)
@@ -155,27 +169,22 @@ Install sliver c2
 - **Find empty directories in sliver path** (ansible.builtin.find)
 - **Remove empty directories** (ansible.builtin.file) - Conditional
 - **Strip debug symbols from binaries** (ansible.builtin.command)
-- **Check for unpacked Go compiler** (ansible.builtin.stat)
-- **Remove unpacked Go compiler if found** (ansible.builtin.file) - Conditional
-- **Check for unpacked Zig compiler** (ansible.builtin.stat)
-- **Remove unpacked Zig compiler if found** (ansible.builtin.file) - Conditional
+- **Check for unpacked compilers in .sliver directory** (ansible.builtin.stat)
+- **Remove unpacked compilers if found** (ansible.builtin.file) - Conditional
 - **Gather package facts** (ansible.builtin.package_facts) - Conditional
-- **Identify MinGW packages to remove** (ansible.builtin.set_fact) - Conditional
-- **Remove MinGW packages** (ansible.builtin.apt) - Conditional
-- **Remove MinGW directories** (ansible.builtin.file)
-- **Remove unnecessary system libraries for containers** (ansible.builtin.apt) - Conditional
-- **Remove development packages** (ansible.builtin.apt) - Conditional
-- **Find Python cache directories** (ansible.builtin.find)
-- **Remove Python cache directories** (ansible.builtin.file)
-- **Find Python compiled files** (ansible.builtin.find)
-- **Remove Python compiled files** (ansible.builtin.file)
-- **Remove pip cache** (ansible.builtin.file)
-- **Find log files** (ansible.builtin.find)
-- **Truncate sliver log files** (ansible.builtin.copy)
-- **Clean sliver user cache directories** (ansible.builtin.file)
-- **Clean root home directories** (ansible.builtin.file)
-- **Final cleanup - remove unnecessary items for container image builds** (ansible.builtin.shell) - Conditional
-- **Unhold git package after cleanup is complete** (ansible.builtin.dpkg_selections) - Conditional
+- **Remove development packages (excluding protected)** (ansible.builtin.apt) - Conditional
+- **Find and remove Python artifacts efficiently** (ansible.builtin.shell)
+- **Truncate log files** (ansible.builtin.shell)
+- **Container-specific optimizations** (block) - Conditional
+- **Remove container-unnecessary locale data** (ansible.builtin.shell)
+- **Remove container-unnecessary system files** (ansible.builtin.file)
+- **Targeted cleanup for specific unnecessary packages** (ansible.builtin.shell) - Conditional
+- **Clean all cache directories once** (ansible.builtin.file)
+- **Verify sliver binaries still work after cleanup** (ansible.builtin.command)
+- **Report binary verification results** (ansible.builtin.debug) - Conditional
+- **Final APT cleanup (last for layer caching)** (ansible.builtin.shell) - Conditional
+- **Unhold protected packages after cleanup** (ansible.builtin.dpkg_selections) - Conditional
+- **Display cleanup summary** (ansible.builtin.debug) - Conditional
 
 ### main.yml
 

--- a/roles/sliver/README.md
+++ b/roles/sliver/README.md
@@ -34,49 +34,67 @@ Install sliver c2
 
 | Variable | Type | Value | Description |
 |----------|------|-------|-------------|
-| `sliver_common_install_packages` | list | `[]` | No description |
-| `sliver_common_install_packages.0` | str | `acl` | No description |
-| `sliver_common_install_packages.1` | str | `git` | No description |
-| `sliver_common_install_packages.2` | str | `gnupg` | No description |
-| `sliver_common_install_packages.3` | str | `make` | No description |
-| `sliver_common_install_packages.4` | str | `wget` | No description |
-| `sliver_common_install_packages.5` | str | `unzip` | No description |
-| `sliver_common_install_packages.6` | str | `zip` | No description |
-| `sliver_debian_packages` | list | `[]` | No description |
-| `sliver_debian_packages.0` | str | `apt-utils` | No description |
-| `sliver_debian_packages.1` | str | `autoconf` | No description |
-| `sliver_debian_packages.2` | str | `build-essential` | No description |
-| `sliver_debian_packages.3` | str | `binutils-mingw-w64` | No description |
-| `sliver_debian_packages.4` | str | `bison` | No description |
-| `sliver_debian_packages.5` | str | `curl` | No description |
-| `sliver_debian_packages.6` | str | `g++-mingw-w64` | No description |
-| `sliver_debian_packages.7` | str | `gpg` | No description |
-| `sliver_debian_packages.8` | str | `libapr1` | No description |
-| `sliver_debian_packages.9` | str | `libcurl4-openssl-dev` | No description |
-| `sliver_debian_packages.10` | str | `libgmp3-dev` | No description |
-| `sliver_debian_packages.11` | str | `libpcap-dev` | No description |
-| `sliver_debian_packages.12` | str | `libpq-dev` | No description |
-| `sliver_debian_packages.13` | str | `libsqlite3-dev` | No description |
-| `sliver_debian_packages.14` | str | `libsvn1` | No description |
-| `sliver_debian_packages.15` | str | `libssl-dev` | No description |
-| `sliver_debian_packages.16` | str | `libtool` | No description |
-| `sliver_debian_packages.17` | str | `libxml2` | No description |
-| `sliver_debian_packages.18` | str | `libxml2-dev` | No description |
-| `sliver_debian_packages.19` | str | `libxslt-dev` | No description |
-| `sliver_debian_packages.20` | str | `libyaml-dev` | No description |
-| `sliver_debian_packages.21` | str | `locate` | No description |
-| `sliver_debian_packages.22` | str | `make` | No description |
-| `sliver_debian_packages.23` | str | `mingw-w64` | No description |
-| `sliver_debian_packages.24` | str | `nasm` | No description |
-| `sliver_debian_packages.25` | str | `ncurses-dev` | No description |
-| `sliver_debian_packages.26` | str | `openssl` | No description |
-| `sliver_debian_packages.27` | str | `patch` | No description |
-| `sliver_debian_packages.28` | str | `postgresql` | No description |
-| `sliver_debian_packages.29` | str | `postgresql-contrib` | No description |
-| `sliver_debian_packages.30` | str | `postgresql-client` | No description |
-| `sliver_debian_packages.31` | str | `xsel` | No description |
-| `sliver_debian_packages.32` | str | `zlib1g` | No description |
-| `sliver_debian_packages.33` | str | `zlib1g-dev` | No description |
+| `sliver_packages` | dict | `{}` | No description |
+| `sliver_packages.essential` | list | `[]` | No description |
+| `sliver_packages.essential.0` | str | `acl` | No description |
+| `sliver_packages.essential.1` | str | `git` | No description |
+| `sliver_packages.essential.2` | str | `gnupg` | No description |
+| `sliver_packages.essential.3` | str | `unzip` | No description |
+| `sliver_packages.essential.4` | str | `zip` | No description |
+| `sliver_packages.build_only` | list | `[]` | No description |
+| `sliver_packages.build_only.0` | str | `make` | No description |
+| `sliver_packages.build_only.1` | str | `wget` | No description |
+| `sliver_packages.build_only.2` | str | `curl` | No description |
+| `sliver_packages.build_only.3` | str | `autoconf` | No description |
+| `sliver_packages.build_only.4` | str | `automake` | No description |
+| `sliver_packages.build_only.5` | str | `build-essential` | No description |
+| `sliver_packages.build_only.6` | str | `gcc` | No description |
+| `sliver_packages.build_only.7` | str | `g++` | No description |
+| `sliver_packages.build_only.8` | str | `libtool` | No description |
+| `sliver_packages.build_only.9` | str | `python3-pip` | No description |
+| `sliver_packages.build_only.10` | str | `ansible` | No description |
+| `sliver_packages.build_only.11` | str | `libssl-dev` | No description |
+| `sliver_packages.build_only.12` | str | `zlib1g-dev` | No description |
+| `sliver_packages.build_only.13` | str | `libncurses5-dev` | No description |
+| `sliver_packages.build_only.14` | str | `libncursesw5-dev` | No description |
+| `sliver_packages.build_only.15` | str | `libreadline-dev` | No description |
+| `sliver_packages.build_only.16` | str | `libsqlite3-dev` | No description |
+| `sliver_packages.build_only.17` | str | `libgdbm-dev` | No description |
+| `sliver_packages.build_only.18` | str | `libdb5.3-dev` | No description |
+| `sliver_packages.build_only.19` | str | `libbz2-dev` | No description |
+| `sliver_packages.build_only.20` | str | `libexpat1-dev` | No description |
+| `sliver_packages.build_only.21` | str | `liblzma-dev` | No description |
+| `sliver_packages.build_only.22` | str | `libffi-dev` | No description |
+| `sliver_packages.runtime_debian` | list | `[]` | No description |
+| `sliver_packages.runtime_debian.0` | str | `apt-utils` | No description |
+| `sliver_packages.runtime_debian.1` | str | `gpg` | No description |
+| `sliver_packages.runtime_debian.2` | str | `openssl` | No description |
+| `sliver_packages.runtime_debian.3` | str | `libapr1` | No description |
+| `sliver_packages.runtime_debian.4` | str | `libsvn1` | No description |
+| `sliver_packages.runtime_debian.5` | str | `libxml2` | No description |
+| `sliver_packages.runtime_debian.6` | str | `zlib1g` | No description |
+| `sliver_packages.runtime_debian.7` | str | `xsel` | No description |
+| `sliver_packages.runtime_debian.8` | str | `libcurl4-openssl-dev` | No description |
+| `sliver_packages.runtime_debian.9` | str | `libgmp3-dev` | No description |
+| `sliver_packages.runtime_debian.10` | str | `libpcap-dev` | No description |
+| `sliver_packages.runtime_debian.11` | str | `libpq-dev` | No description |
+| `sliver_packages.runtime_debian.12` | str | `libxml2-dev` | No description |
+| `sliver_packages.runtime_debian.13` | str | `libxslt-dev` | No description |
+| `sliver_packages.runtime_debian.14` | str | `libyaml-dev` | No description |
+| `sliver_packages.runtime_debian.15` | str | `ncurses-dev` | No description |
+| `sliver_packages.runtime_debian.16` | str | `postgresql` | No description |
+| `sliver_packages.runtime_debian.17` | str | `postgresql-contrib` | No description |
+| `sliver_packages.runtime_debian.18` | str | `postgresql-client` | No description |
+| `sliver_packages.cross_compile` | list | `[]` | No description |
+| `sliver_packages.cross_compile.0` | str | `binutils-mingw-w64` | No description |
+| `sliver_packages.cross_compile.1` | str | `g++-mingw-w64` | No description |
+| `sliver_packages.cross_compile.2` | str | `mingw-w64` | No description |
+| `sliver_packages.cross_compile.3` | str | `bison` | No description |
+| `sliver_packages.cross_compile.4` | str | `nasm` | No description |
+| `sliver_packages.cross_compile.5` | str | `locate` | No description |
+| `sliver_packages.cross_compile.6` | str | `patch` | No description |
+| `sliver_common_install_packages` | str | `{{ sliver_packages.essential + ['make', 'wget', 'curl'] }}` | No description |
+| `sliver_debian_packages` | str | `{{ sliver_packages.build_only + sliver_packages.runtime_debian + sliver_packages.cross_compile }}` | No description |
 | `sliver_el_packages` | list | `[]` | No description |
 | `sliver_el_packages.0` | str | `epel-release` | No description |
 | `sliver_el_packages.1` | str | `gcc` | No description |
@@ -84,24 +102,93 @@ Install sliver c2
 | `sliver_el_packages.3` | str | `protobuf` | No description |
 | `sliver_el_packages.4` | str | `zlib` | No description |
 | `sliver_el_packages.5` | str | `zlib-devel` | No description |
+| `sliver_cleanup_packages_debian` | str | `{{ sliver_packages.build_only + sliver_packages.cross_compile }}` | No description |
+| `sliver_cleanup_paths` | list | `[]` | No description |
+| `sliver_cleanup_paths.0` | str | `{{ sliver_user_home }}/go` | No description |
+| `sliver_cleanup_paths.1` | str | `{{ sliver_user_home }}/.cache` | No description |
+| `sliver_cleanup_paths.2` | str | `{{ sliver_user_home }}/.asdf` | No description |
+| `sliver_cleanup_paths.3` | str | `{{ sliver_user_home }}/.local` | No description |
+| `sliver_cleanup_paths.4` | str | `{{ sliver_user_home }}/.config` | No description |
+| `sliver_cleanup_paths.5` | str | `{{ sliver_user_home }}/.tool-versions` | No description |
+| `sliver_cleanup_paths.6` | str | `/root/go` | No description |
+| `sliver_cleanup_paths.7` | str | `/root/.cache` | No description |
+| `sliver_cleanup_paths.8` | str | `/root/.asdf` | No description |
+| `sliver_cleanup_paths.9` | str | `/root/.local` | No description |
+| `sliver_cleanup_paths.10` | str | `/root/.tool-versions` | No description |
+| `sliver_cleanup_paths.11` | str | `/root/.ssh` | No description |
+| `sliver_system_cleanup_paths` | list | `[]` | No description |
+| `sliver_system_cleanup_paths.0` | str | `/var/lib/apt/lists/*` | No description |
+| `sliver_system_cleanup_paths.1` | str | `/var/cache/apt/*` | No description |
+| `sliver_system_cleanup_paths.2` | str | `/var/cache/debconf/*` | No description |
+| `sliver_system_cleanup_paths.3` | str | `/usr/share/doc/*` | No description |
+| `sliver_system_cleanup_paths.4` | str | `/usr/share/man/*` | No description |
+| `sliver_system_cleanup_paths.5` | str | `/usr/share/locale/*` | No description |
+| `sliver_system_cleanup_paths.6` | str | `/usr/share/info/*` | No description |
+| `sliver_system_cleanup_paths.7` | str | `/tmp/*` | No description |
+| `sliver_system_cleanup_paths.8` | str | `/var/tmp/*` | No description |
+| `sliver_mingw_directories` | list | `[]` | No description |
+| `sliver_mingw_directories.0` | str | `/usr/x86_64-w64-mingw32` | No description |
+| `sliver_mingw_directories.1` | str | `/usr/i686-w64-mingw32` | No description |
+| `sliver_mingw_directories.2` | str | `/usr/x86_64-w64-mingw32ucrt` | No description |
+| `sliver_source_directories` | list | `[]` | No description |
+| `sliver_source_directories.0` | str | `client` | No description |
+| `sliver_source_directories.1` | str | `server` | No description |
+| `sliver_source_directories.2` | str | `implant` | No description |
+| `sliver_source_directories.3` | str | `protobuf` | No description |
+| `sliver_source_directories.4` | str | `util` | No description |
+| `sliver_source_directories.5` | str | `vendor` | No description |
+| `sliver_source_directories.6` | str | `test` | No description |
+| `sliver_source_directories.7` | str | `docs` | No description |
+| `sliver_source_directories.8` | str | `.github` | No description |
+| `sliver_source_directories.9` | str | `.git` | No description |
+| `sliver_keep_binaries` | list | `[]` | No description |
+| `sliver_keep_binaries.0` | str | `sliver-server` | No description |
+| `sliver_keep_binaries.1` | str | `sliver-client` | No description |
+| `sliver_container_remove_packages` | list | `[]` | No description |
+| `sliver_container_remove_packages.0` | str | `*vulkan*` | No description |
+| `sliver_container_remove_packages.1` | str | `*llvm*` | No description |
+| `sliver_container_remove_packages.2` | str | `libicu*` | No description |
+| `sliver_container_remove_packages.3` | str | `snapd` | No description |
+| `sliver_container_remove_packages.4` | str | `libgallium*` | No description |
+| `sliver_container_remove_packages.5` | str | `libasan*` | No description |
 
 ## Tasks
 
 ### cleanup.yml
 
 - **Clean up build environment** (block) - Conditional
-- **Hold git package to prevent removal during cleanup** (ansible.builtin.shell) - Conditional
-- **Remove build-time Go installation and caches** (ansible.builtin.shell)
-- **Clean up sliver directory - keep only binaries** (ansible.builtin.shell)
-- **Clean unpacked compilers if they exist** (ansible.builtin.shell)
-- **Remove MinGW cross-compilation tools** (ansible.builtin.shell)
-- **Remove unnecessary system libraries for containers** (ansible.builtin.shell) - Conditional
-- **Remove all development packages** (ansible.builtin.shell) - Conditional
-- **Final system cleanup** (ansible.builtin.shell)
-- **Clean user directories** (ansible.builtin.shell)
+- **Hold git package to prevent removal during cleanup** (ansible.builtin.dpkg_selections) - Conditional
+- **Remove build-time Go installation and caches** (ansible.builtin.file)
+- **Find non-binary files in sliver directory** (ansible.builtin.find)
+- **Remove non-binary files from sliver directory** (ansible.builtin.file)
+- **Remove source directories from sliver installation** (ansible.builtin.file)
+- **Find empty directories in sliver path** (ansible.builtin.find)
+- **Remove empty directories** (ansible.builtin.file) - Conditional
+- **Strip debug symbols from binaries** (ansible.builtin.command)
+- **Check for unpacked Go compiler** (ansible.builtin.stat)
+- **Remove unpacked Go compiler if found** (ansible.builtin.file) - Conditional
+- **Check for unpacked Zig compiler** (ansible.builtin.stat)
+- **Remove unpacked Zig compiler if found** (ansible.builtin.file) - Conditional
+- **Gather package facts** (ansible.builtin.package_facts) - Conditional
+- **Identify MinGW packages to remove** (ansible.builtin.set_fact) - Conditional
+- **Remove MinGW packages** (ansible.builtin.apt) - Conditional
+- **Remove MinGW directories** (ansible.builtin.file)
+- **Remove unnecessary system libraries for containers** (ansible.builtin.apt) - Conditional
+- **Remove development packages** (ansible.builtin.apt) - Conditional
+- **Remove system cache paths** (ansible.builtin.file)
+- **Find Python cache directories** (ansible.builtin.find)
+- **Remove Python cache directories** (ansible.builtin.file)
+- **Find Python compiled files** (ansible.builtin.find)
+- **Remove Python compiled files** (ansible.builtin.file)
+- **Remove pip cache** (ansible.builtin.file)
+- **Find log files** (ansible.builtin.find)
+- **Truncate sliver log files** (ansible.builtin.copy)
+- **Clean sliver user cache directories** (ansible.builtin.file)
+- **Clean root home directories** (ansible.builtin.file)
 - **Check if PostgreSQL log directory exists** (ansible.builtin.stat)
-- **Truncate PostgreSQL logs if present** (ansible.builtin.shell) - Conditional
-- **Unhold git package after cleanup is complete** (ansible.builtin.shell) - Conditional
+- **Find PostgreSQL log files** (ansible.builtin.find) - Conditional
+- **Truncate PostgreSQL log files** (ansible.builtin.copy) - Conditional
+- **Unhold git package after cleanup is complete** (ansible.builtin.dpkg_selections) - Conditional
 
 ### main.yml
 

--- a/roles/sliver/README.md
+++ b/roles/sliver/README.md
@@ -20,9 +20,10 @@ Install sliver c2
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
+| `sliver_cleanup` | bool | `False` | No description |
 | `sliver_install_path` | str | `/opt/sliver` | No description |
 | `sliver_setup_systemd` | bool | `False` | No description |
-| `sliver_cleanup` | bool | `False` | No description |
+| `sliver_unpack_at_build` | bool | `True` | No description |
 | `sliver_username` | str | `sliver` | No description |
 | `sliver_usergroup` | str | `sliver` | No description |
 | `sliver_shell` | str | `{% if ansible_os_family == 'Darwin' %}/bin/zsh{% else %}/bin/bash{% endif %}` | No description |
@@ -69,12 +70,13 @@ Install sliver c2
 | `sliver_debian_packages.24` | str | `nasm` | No description |
 | `sliver_debian_packages.25` | str | `ncurses-dev` | No description |
 | `sliver_debian_packages.26` | str | `openssl` | No description |
-| `sliver_debian_packages.27` | str | `postgresql` | No description |
-| `sliver_debian_packages.28` | str | `postgresql-contrib` | No description |
-| `sliver_debian_packages.29` | str | `postgresql-client` | No description |
-| `sliver_debian_packages.30` | str | `xsel` | No description |
-| `sliver_debian_packages.31` | str | `zlib1g` | No description |
-| `sliver_debian_packages.32` | str | `zlib1g-dev` | No description |
+| `sliver_debian_packages.27` | str | `patch` | No description |
+| `sliver_debian_packages.28` | str | `postgresql` | No description |
+| `sliver_debian_packages.29` | str | `postgresql-contrib` | No description |
+| `sliver_debian_packages.30` | str | `postgresql-client` | No description |
+| `sliver_debian_packages.31` | str | `xsel` | No description |
+| `sliver_debian_packages.32` | str | `zlib1g` | No description |
+| `sliver_debian_packages.33` | str | `zlib1g-dev` | No description |
 | `sliver_el_packages` | list | `[]` | No description |
 | `sliver_el_packages.0` | str | `epel-release` | No description |
 | `sliver_el_packages.1` | str | `gcc` | No description |
@@ -88,17 +90,18 @@ Install sliver c2
 ### cleanup.yml
 
 - **Clean up build environment** (block) - Conditional
-- **Check if build artifacts exist** (ansible.builtin.stat)
-- **Remove build artifacts and unnecessary files** (ansible.builtin.shell)
-- **Remove Go build environment** (ansible.builtin.file)
-- **Remove development packages (Debian/Ubuntu)** (ansible.builtin.apt) - Conditional
-- **Remove development packages (RedHat/CentOS)** (ansible.builtin.dnf) - Conditional
-- **Clean package manager cache (Debian/Ubuntu)** (ansible.builtin.apt) - Conditional
-- **Remove apt lists** (ansible.builtin.file) - Conditional
-- **Recreate apt lists directory** (ansible.builtin.file) - Conditional
-- **Clean package manager cache (RedHat/CentOS)** (ansible.builtin.command) - Conditional
-- **Remove dnf cache directory** (ansible.builtin.file) - Conditional
-- **Remove temporary files** (ansible.builtin.shell)
+- **Hold git package to prevent removal during cleanup** (ansible.builtin.shell) - Conditional
+- **Remove build-time Go installation and caches** (ansible.builtin.shell)
+- **Clean up sliver directory - keep only binaries** (ansible.builtin.shell)
+- **Clean unpacked compilers if they exist** (ansible.builtin.shell)
+- **Remove MinGW cross-compilation tools** (ansible.builtin.shell)
+- **Remove unnecessary system libraries for containers** (ansible.builtin.shell) - Conditional
+- **Remove all development packages** (ansible.builtin.shell) - Conditional
+- **Final system cleanup** (ansible.builtin.shell)
+- **Clean user directories** (ansible.builtin.shell)
+- **Check if PostgreSQL log directory exists** (ansible.builtin.stat)
+- **Truncate PostgreSQL logs if present** (ansible.builtin.shell) - Conditional
+- **Unhold git package after cleanup is complete** (ansible.builtin.shell) - Conditional
 
 ### main.yml
 
@@ -123,7 +126,7 @@ Install sliver c2
 - **Check current ownership of {{ sliver_install_path }}** (ansible.builtin.stat)
 - **Ensure correct ownership of the Sliver repository** (ansible.builtin.file) - Conditional
 - **Set up Go version in Sliver directory** (ansible.builtin.copy) - Conditional
-- **Add sliver_install_path to $PATH** (ansible.builtin.lineinfile)
+- **Add Sliver paths to user's bashrc** (ansible.builtin.blockinfile)
 - **Check if Sliver server exists** (ansible.builtin.stat)
 - **Ensure golang is installed for user** (ansible.builtin.shell) - Conditional
 - **Compile sliver** (ansible.builtin.shell) - Conditional

--- a/roles/sliver/README.md
+++ b/roles/sliver/README.md
@@ -116,16 +116,6 @@ Install sliver c2
 | `sliver_cleanup_paths.9` | str | `/root/.local` | No description |
 | `sliver_cleanup_paths.10` | str | `/root/.tool-versions` | No description |
 | `sliver_cleanup_paths.11` | str | `/root/.ssh` | No description |
-| `sliver_system_cleanup_paths` | list | `[]` | No description |
-| `sliver_system_cleanup_paths.0` | str | `/var/lib/apt/lists/*` | No description |
-| `sliver_system_cleanup_paths.1` | str | `/var/cache/apt/*` | No description |
-| `sliver_system_cleanup_paths.2` | str | `/var/cache/debconf/*` | No description |
-| `sliver_system_cleanup_paths.3` | str | `/usr/share/doc/*` | No description |
-| `sliver_system_cleanup_paths.4` | str | `/usr/share/man/*` | No description |
-| `sliver_system_cleanup_paths.5` | str | `/usr/share/locale/*` | No description |
-| `sliver_system_cleanup_paths.6` | str | `/usr/share/info/*` | No description |
-| `sliver_system_cleanup_paths.7` | str | `/tmp/*` | No description |
-| `sliver_system_cleanup_paths.8` | str | `/var/tmp/*` | No description |
 | `sliver_mingw_directories` | list | `[]` | No description |
 | `sliver_mingw_directories.0` | str | `/usr/x86_64-w64-mingw32` | No description |
 | `sliver_mingw_directories.1` | str | `/usr/i686-w64-mingw32` | No description |
@@ -175,7 +165,6 @@ Install sliver c2
 - **Remove MinGW directories** (ansible.builtin.file)
 - **Remove unnecessary system libraries for containers** (ansible.builtin.apt) - Conditional
 - **Remove development packages** (ansible.builtin.apt) - Conditional
-- **Remove system cache paths** (ansible.builtin.file)
 - **Find Python cache directories** (ansible.builtin.find)
 - **Remove Python cache directories** (ansible.builtin.file)
 - **Find Python compiled files** (ansible.builtin.find)
@@ -185,9 +174,7 @@ Install sliver c2
 - **Truncate sliver log files** (ansible.builtin.copy)
 - **Clean sliver user cache directories** (ansible.builtin.file)
 - **Clean root home directories** (ansible.builtin.file)
-- **Check if PostgreSQL log directory exists** (ansible.builtin.stat)
-- **Find PostgreSQL log files** (ansible.builtin.find) - Conditional
-- **Truncate PostgreSQL log files** (ansible.builtin.copy) - Conditional
+- **Final cleanup - remove unnecessary items for container image builds** (ansible.builtin.shell) - Conditional
 - **Unhold git package after cleanup is complete** (ansible.builtin.dpkg_selections) - Conditional
 
 ### main.yml

--- a/roles/sliver/defaults/main.yml
+++ b/roles/sliver/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
+sliver_cleanup: false  # Enable for Docker/container builds to minimize image size
 sliver_install_path: /opt/sliver
 sliver_setup_systemd: false
-sliver_cleanup: false  # Enable for Docker/container builds to minimize image size
+sliver_unpack_at_build: true # Disable to skip unpacking at build time for Docker/container builds
 
 sliver_username: "sliver"
 sliver_usergroup: "sliver"
@@ -9,5 +10,5 @@ sliver_shell: "{% if ansible_os_family == 'Darwin' %}/bin/zsh{% else %}/bin/bash
 sliver_asdf_plugins:
   # renovate: datasource=github-tags depName=golang packageName=golang/go extractVersion=^go(?<version>.*)$
   - name: golang
-    version: "1.25.1"
+    version: "1.24.5"
     scope: "global"

--- a/roles/sliver/tasks/cleanup.yml
+++ b/roles/sliver/tasks/cleanup.yml
@@ -2,102 +2,179 @@
 - name: Clean up build environment
   when: sliver_cleanup | bool
   block:
-    - name: Check if build artifacts exist
-      ansible.builtin.stat:
-        path: "{{ sliver_install_path }}/.git"
-      register: sliver_git_dir
-
-    - name: Remove build artifacts and unnecessary files
-      ansible.builtin.shell: |
-        # Clean up Sliver build artifacts
-        cd {{ sliver_install_path }}
-        find . -name "*.o" -delete 2>/dev/null || true
-        find . -name "*.a" -delete 2>/dev/null || true
-        rm -rf .git test docs .github 2>/dev/null || true
-        rm -rf server/assets/fs/darwin 2>/dev/null || true
-        rm -rf server/assets/fs/windows 2>/dev/null || true
-        rm -rf server/assets/fs/linux 2>/dev/null || true
-
-        # Strip debug symbols from binaries if they exist
-        if [ -f {{ sliver_install_path }}/sliver-server ]; then
-          strip {{ sliver_install_path }}/sliver-server || true
-        fi
-        if [ -f {{ sliver_install_path }}/sliver-client ]; then
-          strip {{ sliver_install_path }}/sliver-client || true
-        fi
-      args:
-        executable: /bin/bash
+    - name: Hold git package to prevent removal during cleanup
+      ansible.builtin.shell: apt-mark hold git
       become: true
-      changed_when: sliver_git_dir.stat.exists
+      when: ansible_os_family == "Debian"
 
-    - name: Remove Go build environment
+    - name: Remove build-time Go installation and caches
       ansible.builtin.file:
         path: "{{ item }}"
         state: absent
       loop:
         - "{{ sliver_user_home }}/go"
-        - "{{ sliver_user_home }}/.cache/go-build"
+        - "{{ sliver_user_home }}/.cache"
         - "{{ sliver_user_home }}/.asdf"
+        - "/root/go"
+        - "/root/.cache"
+        - "/root/.asdf"
+        - "/root/.local"
+        - "/root/.tool-versions"
       become: true
 
-    - name: Remove development packages (Debian/Ubuntu)
-      ansible.builtin.apt:
-        name: "{{ sliver_debian_packages }}"
-        state: absent
-        autoremove: true
-        autoclean: true
-      when: ansible_os_family == "Debian"
-      become: true
-      failed_when: false
-
-    - name: Remove development packages (RedHat/CentOS)
-      ansible.builtin.dnf:
-        name: "{{ sliver_el_packages }}"
-        state: absent
-        autoremove: true
-      when: ansible_os_family == "RedHat"
-      become: true
-      failed_when: false
-
-    - name: Clean package manager cache (Debian/Ubuntu)
-      ansible.builtin.apt:
-        clean: true
-      when: ansible_os_family == "Debian"
-      become: true
-
-    - name: Remove apt lists
-      ansible.builtin.file:
-        path: /var/lib/apt/lists
-        state: absent
-      when: ansible_os_family == "Debian"
-      become: true
-
-    - name: Recreate apt lists directory
-      ansible.builtin.file:
-        path: /var/lib/apt/lists
-        state: directory
-        mode: '0755'
-      when: ansible_os_family == "Debian"
-      become: true
-
-    - name: Clean package manager cache (RedHat/CentOS)
-      ansible.builtin.command:
-        cmd: dnf clean all
-      when: ansible_os_family == "RedHat"
-      become: true
-      changed_when: true
-
-    - name: Remove dnf cache directory
-      ansible.builtin.file:
-        path: /var/cache/dnf
-        state: absent
-      when: ansible_os_family == "RedHat"
-      become: true
-
-    - name: Remove temporary files
+    - name: Clean up sliver directory - keep only binaries
       ansible.builtin.shell: |
-        rm -rf /tmp/* /var/tmp/* 2>/dev/null || true
+        cd {{ sliver_install_path }}
+        # Remove all source directories
+        rm -rf client/ server/ implant/ protobuf/ util/ vendor/ test/ docs/ .github/ .git/
+        # Remove all files except the binaries
+        find . -maxdepth 1 -type f ! -name "sliver-server" ! -name "sliver-client" -delete 2>/dev/null || true
+        # Remove any empty directories
+        find . -type d -empty -delete 2>/dev/null || true
+
+        # Strip debug symbols from binaries to reduce size
+        strip sliver-server 2>/dev/null || true
+        strip sliver-client 2>/dev/null || true
       args:
         executable: /bin/bash
       become: true
-      changed_when: false
+
+    - name: Clean unpacked compilers if they exist
+      ansible.builtin.shell: >
+        if [ -d "{{ sliver_user_home }}/.sliver/go" ]; then
+          echo "Removing unexpectedly found Go compiler..." &&
+          rm -rf "{{ sliver_user_home }}/.sliver/go";
+        fi;
+        if [ -d "{{ sliver_user_home }}/.sliver/zig" ]; then
+          echo "Removing unexpectedly found Zig compiler..." &&
+          rm -rf "{{ sliver_user_home }}/.sliver/zig";
+        fi
+      args:
+        executable: /bin/bash
+      become: true
+
+    - name: Remove MinGW cross-compilation tools
+      ansible.builtin.shell: |
+        # Get list of MinGW packages (exclude git if it somehow appears)
+        MINGW_PACKAGES=$(dpkg -l | grep -E 'mingw|w64' | grep -v ' git ' | awk '{print $2}' | tr '\n' ' ')
+
+        if [ -n "$MINGW_PACKAGES" ]; then
+          echo "Removing MinGW packages: $MINGW_PACKAGES"
+          apt-get remove -y --purge $MINGW_PACKAGES
+        fi
+
+        # Force remove MinGW directories
+        rm -rf /usr/x86_64-w64-mingw32
+        rm -rf /usr/i686-w64-mingw32
+        rm -rf /usr/x86_64-w64-mingw32ucrt
+      args:
+        executable: /bin/bash
+      become: true
+
+    - name: Remove unnecessary system libraries for containers
+      ansible.builtin.shell: |
+        # Remove graphics/large libraries not needed for Sliver
+        REMOVE_PACKAGES=""
+
+        # Check and add packages to remove list (exclude git-related packages)
+        for pkg in '*vulkan*' '*llvm*' 'libicu*' 'snapd' 'libgallium*' 'libasan*'; do
+          if dpkg -l | grep -q "$pkg" && ! echo "$pkg" | grep -q git; then
+            REMOVE_PACKAGES="$REMOVE_PACKAGES $pkg"
+          fi
+        done
+
+        if [ -n "$REMOVE_PACKAGES" ]; then
+          apt-get remove -y --purge $REMOVE_PACKAGES || true
+        fi
+      args:
+        executable: /bin/bash
+      become: true
+      when: ansible_virtualization_type == "docker"
+      failed_when: false
+
+    - name: Remove all development packages
+      ansible.builtin.shell: |
+        #!/bin/bash
+        PACKAGES_TO_REMOVE="build-essential gcc g++ make wget curl autoconf automake libtool python3-pip ansible"
+
+        # Add any -dev packages
+        for pkg in libssl-dev zlib1g-dev libncurses5-dev libncursesw5-dev libreadline-dev libsqlite3-dev libgdbm-dev libdb5.3-dev libbz2-dev libexpat1-dev liblzma-dev libffi-dev; do
+          if dpkg -l | grep -q "^ii  ${pkg}"; then
+            PACKAGES_TO_REMOVE="${PACKAGES_TO_REMOVE} ${pkg}"
+          fi
+        done
+
+        # Remove the packages
+        apt-get remove -y --purge ${PACKAGES_TO_REMOVE}
+
+        # Run autoremove (git will be protected by hold)
+        apt-get autoremove -y --purge
+        apt-get clean
+      args:
+        executable: /bin/bash
+      when: ansible_os_family == "Debian"
+      become: true
+
+    - name: Final system cleanup
+      ansible.builtin.shell: |
+        # Remove package caches
+        rm -rf /var/lib/apt/lists/*
+        rm -rf /var/cache/apt/*
+        rm -rf /var/cache/debconf/*
+
+        # Remove documentation
+        rm -rf /usr/share/doc/*
+        rm -rf /usr/share/man/*
+        rm -rf /usr/share/locale/*
+        rm -rf /usr/share/info/*
+
+        # Remove Python cache
+        find /usr -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true
+        find /usr -type f -name '*.pyc' -delete 2>/dev/null || true
+        rm -rf /root/.cache/pip
+
+        # Clean tmp directories
+        rm -rf /tmp/* /var/tmp/*
+
+        # Truncate logs
+        find /var/log -type f -exec truncate -s 0 {} \; 2>/dev/null || true
+      args:
+        executable: /bin/bash
+      become: true
+
+    - name: Clean user directories
+      ansible.builtin.shell: |
+        # Clean sliver user home but preserve .sliver structure
+        rm -rf {{ sliver_user_home }}/.cache
+        rm -rf {{ sliver_user_home }}/.local
+        rm -rf {{ sliver_user_home }}/.config
+        rm -rf {{ sliver_user_home }}/.tool-versions
+
+        # Clean root home (but preserve git config if it exists)
+        rm -rf /root/.asdf
+        rm -rf /root/.local
+        rm -rf /root/.tool-versions
+        rm -rf /root/.ssh
+      args:
+        executable: /bin/bash
+      become: true
+
+    - name: Check if PostgreSQL log directory exists
+      ansible.builtin.stat:
+        path: /var/log/postgresql
+      register: sliver_postgresql_log_dir
+      become: true
+
+    - name: Truncate PostgreSQL logs if present
+      ansible.builtin.shell: |
+        find /var/log/postgresql -type f -name "*.log" -exec truncate -s 0 {} \; 2>/dev/null || true
+      args:
+        executable: /bin/bash
+      when: sliver_postgresql_log_dir.stat.exists and sliver_postgresql_log_dir.stat.isdir
+      become: true
+      failed_when: false
+
+    - name: Unhold git package after cleanup is complete
+      ansible.builtin.shell: apt-mark unhold git
+      become: true
+      when: ansible_os_family == "Debian"

--- a/roles/sliver/tasks/cleanup.yml
+++ b/roles/sliver/tasks/cleanup.yml
@@ -3,7 +3,9 @@
   when: sliver_cleanup | bool
   block:
     - name: Hold git package to prevent removal during cleanup
-      ansible.builtin.shell: apt-mark hold git
+      ansible.builtin.dpkg_selections:
+        name: git
+        selection: hold
       become: true
       when: ansible_os_family == "Debian"
 
@@ -11,152 +13,219 @@
       ansible.builtin.file:
         path: "{{ item }}"
         state: absent
-      loop:
-        - "{{ sliver_user_home }}/go"
-        - "{{ sliver_user_home }}/.cache"
-        - "{{ sliver_user_home }}/.asdf"
-        - "/root/go"
-        - "/root/.cache"
-        - "/root/.asdf"
-        - "/root/.local"
-        - "/root/.tool-versions"
+      loop: "{{ sliver_cleanup_paths }}"
       become: true
 
-    - name: Clean up sliver directory - keep only binaries
-      ansible.builtin.shell: |
-        cd {{ sliver_install_path }}
-        # Remove all source directories
-        rm -rf client/ server/ implant/ protobuf/ util/ vendor/ test/ docs/ .github/ .git/
-        # Remove all files except the binaries
-        find . -maxdepth 1 -type f ! -name "sliver-server" ! -name "sliver-client" -delete 2>/dev/null || true
-        # Remove any empty directories
-        find . -type d -empty -delete 2>/dev/null || true
-
-        # Strip debug symbols from binaries to reduce size
-        strip sliver-server 2>/dev/null || true
-        strip sliver-client 2>/dev/null || true
-      args:
-        executable: /bin/bash
+    - name: Find non-binary files in sliver directory
+      ansible.builtin.find:
+        paths: "{{ sliver_install_path }}"
+        file_type: file
+        recurse: false
+        excludes: "{{ sliver_keep_binaries }}"
+      register: sliver_files_to_remove
       become: true
 
-    - name: Clean unpacked compilers if they exist
-      ansible.builtin.shell: >
-        if [ -d "{{ sliver_user_home }}/.sliver/go" ]; then
-          echo "Removing unexpectedly found Go compiler..." &&
-          rm -rf "{{ sliver_user_home }}/.sliver/go";
-        fi;
-        if [ -d "{{ sliver_user_home }}/.sliver/zig" ]; then
-          echo "Removing unexpectedly found Zig compiler..." &&
-          rm -rf "{{ sliver_user_home }}/.sliver/zig";
-        fi
-      args:
-        executable: /bin/bash
+    - name: Remove non-binary files from sliver directory
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ sliver_files_to_remove.files }}"
       become: true
 
-    - name: Remove MinGW cross-compilation tools
-      ansible.builtin.shell: |
-        # Get list of MinGW packages (exclude git if it somehow appears)
-        MINGW_PACKAGES=$(dpkg -l | grep -E 'mingw|w64' | grep -v ' git ' | awk '{print $2}' | tr '\n' ' ')
-
-        if [ -n "$MINGW_PACKAGES" ]; then
-          echo "Removing MinGW packages: $MINGW_PACKAGES"
-          apt-get remove -y --purge $MINGW_PACKAGES
-        fi
-
-        # Force remove MinGW directories
-        rm -rf /usr/x86_64-w64-mingw32
-        rm -rf /usr/i686-w64-mingw32
-        rm -rf /usr/x86_64-w64-mingw32ucrt
-      args:
-        executable: /bin/bash
+    - name: Remove source directories from sliver installation
+      ansible.builtin.file:
+        path: "{{ sliver_install_path }}/{{ item }}"
+        state: absent
+      loop: "{{ sliver_source_directories }}"
       become: true
 
-    - name: Remove unnecessary system libraries for containers
-      ansible.builtin.shell: |
-        # Remove graphics/large libraries not needed for Sliver
-        REMOVE_PACKAGES=""
-
-        # Check and add packages to remove list (exclude git-related packages)
-        for pkg in '*vulkan*' '*llvm*' 'libicu*' 'snapd' 'libgallium*' 'libasan*'; do
-          if dpkg -l | grep -q "$pkg" && ! echo "$pkg" | grep -q git; then
-            REMOVE_PACKAGES="$REMOVE_PACKAGES $pkg"
-          fi
-        done
-
-        if [ -n "$REMOVE_PACKAGES" ]; then
-          apt-get remove -y --purge $REMOVE_PACKAGES || true
-        fi
-      args:
-        executable: /bin/bash
+    - name: Find empty directories in sliver path
+      ansible.builtin.find:
+        paths: "{{ sliver_install_path }}"
+        file_type: directory
+        recurse: true
+      register: sliver_all_dirs
       become: true
-      when: ansible_virtualization_type == "docker"
+
+    - name: Remove empty directories
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ sliver_all_dirs.files }}"
+      when: item.size == 0
+      become: true
+
+    - name: Strip debug symbols from binaries
+      ansible.builtin.command:
+        cmd: "strip {{ sliver_install_path }}/{{ item }}"
+      loop: "{{ sliver_keep_binaries }}"
+      become: true
+      changed_when: false
       failed_when: false
 
-    - name: Remove all development packages
-      ansible.builtin.shell: |
-        #!/bin/bash
-        PACKAGES_TO_REMOVE="build-essential gcc g++ make wget curl autoconf automake libtool python3-pip ansible"
+    - name: Check for unpacked Go compiler
+      ansible.builtin.stat:
+        path: "{{ sliver_user_home }}/.sliver/go"
+      register: sliver_go_compiler
+      become: true
 
-        # Add any -dev packages
-        for pkg in libssl-dev zlib1g-dev libncurses5-dev libncursesw5-dev libreadline-dev libsqlite3-dev libgdbm-dev libdb5.3-dev libbz2-dev libexpat1-dev liblzma-dev libffi-dev; do
-          if dpkg -l | grep -q "^ii  ${pkg}"; then
-            PACKAGES_TO_REMOVE="${PACKAGES_TO_REMOVE} ${pkg}"
-          fi
-        done
+    - name: Remove unpacked Go compiler if found
+      ansible.builtin.file:
+        path: "{{ sliver_user_home }}/.sliver/go"
+        state: absent
+      when: sliver_go_compiler.stat.exists
+      become: true
 
-        # Remove the packages
-        apt-get remove -y --purge ${PACKAGES_TO_REMOVE}
+    - name: Check for unpacked Zig compiler
+      ansible.builtin.stat:
+        path: "{{ sliver_user_home }}/.sliver/zig"
+      register: sliver_zig_compiler
+      become: true
 
-        # Run autoremove (git will be protected by hold)
-        apt-get autoremove -y --purge
-        apt-get clean
-      args:
-        executable: /bin/bash
+    - name: Remove unpacked Zig compiler if found
+      ansible.builtin.file:
+        path: "{{ sliver_user_home }}/.sliver/zig"
+        state: absent
+      when: sliver_zig_compiler.stat.exists
+      become: true
+
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+        manager: apt
       when: ansible_os_family == "Debian"
       become: true
 
-    - name: Final system cleanup
-      ansible.builtin.shell: |
-        # Remove package caches
-        rm -rf /var/lib/apt/lists/*
-        rm -rf /var/cache/apt/*
-        rm -rf /var/cache/debconf/*
+    - name: Identify MinGW packages to remove
+      ansible.builtin.set_fact:
+        sliver_mingw_packages_to_remove: "{{ ansible_facts.packages.keys() | select('match', '.*mingw.*|.*w64.*') | reject('match', '.*git.*') | list }}"
+      when:
+        - ansible_os_family == "Debian"
+        - ansible_facts.packages is defined
 
-        # Remove documentation
-        rm -rf /usr/share/doc/*
-        rm -rf /usr/share/man/*
-        rm -rf /usr/share/locale/*
-        rm -rf /usr/share/info/*
-
-        # Remove Python cache
-        find /usr -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true
-        find /usr -type f -name '*.pyc' -delete 2>/dev/null || true
-        rm -rf /root/.cache/pip
-
-        # Clean tmp directories
-        rm -rf /tmp/* /var/tmp/*
-
-        # Truncate logs
-        find /var/log -type f -exec truncate -s 0 {} \; 2>/dev/null || true
-      args:
-        executable: /bin/bash
+    - name: Remove MinGW packages
+      ansible.builtin.apt:
+        name: "{{ sliver_mingw_packages_to_remove }}"
+        state: absent
+        purge: true
+      when:
+        - ansible_os_family == "Debian"
+        - sliver_mingw_packages_to_remove is defined
+        - sliver_mingw_packages_to_remove | length > 0
       become: true
 
-    - name: Clean user directories
-      ansible.builtin.shell: |
-        # Clean sliver user home but preserve .sliver structure
-        rm -rf {{ sliver_user_home }}/.cache
-        rm -rf {{ sliver_user_home }}/.local
-        rm -rf {{ sliver_user_home }}/.config
-        rm -rf {{ sliver_user_home }}/.tool-versions
+    - name: Remove MinGW directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ sliver_mingw_directories }}"
+      become: true
 
-        # Clean root home (but preserve git config if it exists)
-        rm -rf /root/.asdf
-        rm -rf /root/.local
-        rm -rf /root/.tool-versions
-        rm -rf /root/.ssh
-      args:
-        executable: /bin/bash
+    - name: Remove unnecessary system libraries for containers
+      ansible.builtin.apt:
+        name: "{{ sliver_container_remove_packages }}"
+        state: absent
+        purge: true
+      when:
+        - ansible_os_family == "Debian"
+        - ansible_virtualization_type == "docker"
+      become: true
+      failed_when: false
+
+    - name: Remove development packages
+      ansible.builtin.apt:
+        name: "{{ sliver_cleanup_packages_debian }}"
+        state: absent
+        purge: true
+        autoremove: true
+        autoclean: true
+      when: ansible_os_family == "Debian"
+      become: true
+
+    - name: Remove system cache paths
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ sliver_system_cleanup_paths }}"
+      become: true
+
+    - name: Find Python cache directories
+      ansible.builtin.find:
+        paths: /usr
+        patterns: "__pycache__"
+        file_type: directory
+        recurse: true
+      register: sliver_pycache_dirs
+      become: true
+      failed_when: false
+
+    - name: Remove Python cache directories
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ sliver_pycache_dirs.files | default([]) }}"
+      become: true
+
+    - name: Find Python compiled files
+      ansible.builtin.find:
+        paths: /usr
+        patterns: "*.pyc"
+        file_type: file
+        recurse: true
+      register: sliver_pyc_files
+      become: true
+      failed_when: false
+
+    - name: Remove Python compiled files
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ sliver_pyc_files.files | default([]) }}"
+      become: true
+
+    - name: Remove pip cache
+      ansible.builtin.file:
+        path: /root/.cache/pip
+        state: absent
+      become: true
+
+    - name: Find log files
+      ansible.builtin.find:
+        paths: /var/log
+        file_type: file
+        recurse: true
+      register: sliver_log_files
+      become: true
+      failed_when: false
+
+    - name: Truncate sliver log files
+      ansible.builtin.copy:
+        content: ""
+        dest: "{{ item.path }}"
+        mode: '0644'
+      loop: "{{ sliver_log_files.files | default([]) }}"
+      become: true
+      changed_when: false
+
+    - name: Clean sliver user cache directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ sliver_user_home }}/.cache"
+        - "{{ sliver_user_home }}/.local"
+        - "{{ sliver_user_home }}/.config"
+        - "{{ sliver_user_home }}/.tool-versions"
+      become: true
+
+    - name: Clean root home directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /root/.asdf
+        - /root/.local
+        - /root/.tool-versions
+        - /root/.ssh
       become: true
 
     - name: Check if PostgreSQL log directory exists
@@ -165,16 +234,31 @@
       register: sliver_postgresql_log_dir
       become: true
 
-    - name: Truncate PostgreSQL logs if present
-      ansible.builtin.shell: |
-        find /var/log/postgresql -type f -name "*.log" -exec truncate -s 0 {} \; 2>/dev/null || true
-      args:
-        executable: /bin/bash
-      when: sliver_postgresql_log_dir.stat.exists and sliver_postgresql_log_dir.stat.isdir
+    - name: Find PostgreSQL log files
+      ansible.builtin.find:
+        paths: /var/log/postgresql
+        patterns: "*.log"
+        file_type: file
+      register: sliver_postgres_logs
+      when:
+        - sliver_postgresql_log_dir.stat.exists
+        - sliver_postgresql_log_dir.stat.isdir
       become: true
       failed_when: false
 
+    - name: Truncate PostgreSQL log files
+      ansible.builtin.copy:
+        content: ""
+        dest: "{{ item.path }}"
+        mode: '0644'
+      loop: "{{ sliver_postgres_logs.files | default([]) }}"
+      when: sliver_postgres_logs.files is defined
+      become: true
+      changed_when: false
+
     - name: Unhold git package after cleanup is complete
-      ansible.builtin.shell: apt-mark unhold git
+      ansible.builtin.dpkg_selections:
+        name: git
+        selection: install
       become: true
       when: ansible_os_family == "Debian"

--- a/roles/sliver/tasks/cleanup.yml
+++ b/roles/sliver/tasks/cleanup.yml
@@ -141,13 +141,7 @@
       when: ansible_os_family == "Debian"
       become: true
 
-    - name: Remove system cache paths
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: absent
-      loop: "{{ sliver_system_cleanup_paths }}"
-      become: true
-
+    # Keep the Ansible-native Python cleanup but supplement it
     - name: Find Python cache directories
       ansible.builtin.find:
         paths: /usr
@@ -228,32 +222,173 @@
         - /root/.ssh
       become: true
 
-    - name: Check if PostgreSQL log directory exists
-      ansible.builtin.stat:
-        path: /var/log/postgresql
-      register: sliver_postgresql_log_dir
-      become: true
+    - name: Final cleanup - remove unnecessary items for container image builds
+      ansible.builtin.shell: |
+        set -e
 
-    - name: Find PostgreSQL log files
-      ansible.builtin.find:
-        paths: /var/log/postgresql
-        patterns: "*.log"
-        file_type: file
-      register: sliver_postgres_logs
-      when:
-        - sliver_postgresql_log_dir.stat.exists
-        - sliver_postgresql_log_dir.stat.isdir
+        echo "=== Starting ultra-aggressive cleanup ==="
+
+        # Remove LLVM and graphics libraries
+        apt-get remove -y --purge \
+          libllvm* llvm* \
+          libgallium* \
+          libvulkan* vulkan* \
+          libgl* libgles* \
+          libdrm* \
+          mesa* \
+          2>/dev/null || true
+
+        # Remove snapd
+        apt-get remove -y --purge snapd snap-confine ubuntu-core-launcher 2>/dev/null || true
+        rm -rf /usr/lib/snapd
+        rm -rf /snap
+        rm -rf /var/snap
+        rm -rf /var/lib/snapd
+
+        # Remove ICU internationalization
+        apt-get remove -y --purge libicu* icu-* 2>/dev/null || true
+
+        # Remove development packages and compilers
+        apt-get remove -y --purge \
+          *-dev *-dbg *-doc \
+          gcc* g++* cpp* \
+          build-essential libtool cmake dpkg-dev \
+          linux-libc-dev libc6-dev libc-dev-bin \
+          manpages manpages-dev \
+          2>/dev/null || true
+
+        # Remove GCC
+        rm -rf /usr/libexec/gcc
+        rm -rf /usr/lib/gcc
+
+        # Remove Perl
+        apt-get remove -y --purge perl perl-base perl-modules-* 2>/dev/null || true
+        rm -rf /usr/lib/aarch64-linux-gnu/perl*
+        rm -rf /usr/share/perl*
+
+        # Remove Python packages
+        apt-get remove -y --purge \
+          python3-pip python3-setuptools python3-wheel \
+          python3-dev python3-venv \
+          2>/dev/null || true
+
+        # Remove other unnecessary packages
+        apt-get remove -y --purge \
+          openssh-server \
+          krb5-locales \
+          publicsuffix \
+          xauth \
+          fontconfig* fonts-* \
+          libgtk* libgdk* \
+          libasound* libpulse* \
+          libx11-* libxext* libxrender* libxtst* \
+          2>/dev/null || true
+
+        # Clean PostgreSQL - remove bitcode and unnecessary components
+        rm -rf /usr/lib/postgresql/*/lib/bitcode
+        rm -rf /usr/lib/postgresql/*/lib/pgxs
+        rm -rf /usr/share/postgresql/*/extension
+        find /usr/lib/postgresql -name "*.bc" -delete 2>/dev/null || true
+
+        # Remove file magic database
+        rm -f /usr/lib/file/magic.mgc
+
+        # Remove udev hardware database
+        rm -f /usr/lib/udev/hwdb.bin
+
+        # Purge any packages that were automatically installed as dependencies
+        apt-get autoremove -y --purge
+
+        # Mark all libraries as auto-installed and remove unused
+        apt-mark auto ".*" 2>/dev/null || true
+        apt-mark manual git sliver-server sliver-client postgresql postgresql-client postgresql-contrib 2>/dev/null || true
+        apt-get autoremove -y --purge
+
+        # Clean package manager completely
+        apt-get clean
+        apt-get autoclean
+        rm -rf /var/lib/apt/lists/*
+        rm -rf /var/cache/apt/*
+        rm -rf /var/cache/debconf/*
+        rm -rf /var/lib/dpkg/*-old
+        rm -rf /var/lib/dpkg/backup/*
+
+        # Remove all documentation and man pages
+        rm -rf /usr/share/doc
+        rm -rf /usr/share/man
+        rm -rf /usr/share/info
+        rm -rf /usr/share/lintian
+        rm -rf /usr/share/linda
+        rm -rf /usr/share/bug
+
+        # Remove all locales except C
+        rm -rf /usr/share/locale/*
+
+        # Remove misc shared data
+        rm -rf /usr/share/zoneinfo
+        rm -rf /usr/share/i18n
+        rm -rf /usr/share/common-licenses
+        rm -rf /usr/share/mime
+        rm -rf /usr/share/pixmaps
+        rm -rf /usr/share/applications
+        rm -rf /usr/share/menu
+        rm -rf /usr/share/sounds
+        rm -rf /usr/share/icons
+        rm -rf /usr/share/fonts
+        rm -rf /usr/share/terminfo
+        rm -rf /usr/share/X11
+        rm -rf /usr/share/bash-completion
+
+        # Remove all static libraries and headers
+        find /usr -name "*.a" -delete 2>/dev/null || true
+        find /usr -name "*.la" -delete 2>/dev/null || true
+        rm -rf /usr/include
+
+        # Remove Python stuff we do not need
+        rm -rf /usr/lib/python*/test
+        rm -rf /usr/lib/python*/tests
+        rm -rf /usr/lib/python*/idle*
+        rm -rf /usr/lib/python*/tkinter
+        rm -rf /usr/lib/python*/unittest
+        rm -rf /usr/lib/python*/ensurepip
+        rm -rf /usr/lib/python*/distutils
+        rm -rf /usr/lib/python*/lib2to3
+        rm -rf /usr/lib/python*/pydoc*
+        rm -rf /usr/lib/python*/config-*
+        find /usr -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+        find /usr -type f -name "*.pyc" -delete 2>/dev/null || true
+        find /usr -type f -name "*.pyo" -delete 2>/dev/null || true
+
+        # Clean all caches
+        rm -rf /var/cache/*
+        rm -rf /root/.cache
+        rm -rf /root/.local
+        rm -rf /root/.config
+        rm -rf /home/*/.cache
+        rm -rf /home/*/.local
+        rm -rf /home/*/.config
+
+        # Clean tmp
+        rm -rf /tmp/* /var/tmp/*
+
+        # Remove all logs
+        find /var/log -type f -delete 2>/dev/null || true
+
+        # Remove cron, systemd catalog, etc
+        rm -rf /var/spool/cron
+        rm -rf /var/spool/mail
+        rm -rf /var/lib/systemd/catalog
+
+        # Cleanup any remaining build artifacts
+        find / -name "*.o" -delete 2>/dev/null || true
+        find / -name "*.lo" -delete 2>/dev/null || true
+
+        echo "=== Cleanup complete ==="
+      args:
+        executable: /bin/bash
       become: true
+      when: ansible_os_family == "Debian"
       failed_when: false
-
-    - name: Truncate PostgreSQL log files
-      ansible.builtin.copy:
-        content: ""
-        dest: "{{ item.path }}"
-        mode: '0644'
-      loop: "{{ sliver_postgres_logs.files | default([]) }}"
-      when: sliver_postgres_logs.files is defined
-      become: true
       changed_when: false
 
     - name: Unhold git package after cleanup is complete

--- a/roles/sliver/tasks/cleanup.yml
+++ b/roles/sliver/tasks/cleanup.yml
@@ -2,12 +2,20 @@
 - name: Clean up build environment
   when: sliver_cleanup | bool
   block:
-    - name: Hold git package to prevent removal during cleanup
-      ansible.builtin.dpkg_selections:
-        name: git
-        selection: hold
-      become: true
+    - name: Create list of packages to protect
+      ansible.builtin.set_fact:
+        sliver_protected_packages: "{{ (sliver_packages.essential | default([])) + (sliver_packages.runtime_debian | default([])) | unique }}"
       when: ansible_os_family == "Debian"
+
+    - name: Hold runtime and essential packages before cleanup
+      ansible.builtin.dpkg_selections:
+        name: "{{ item }}"
+        selection: hold
+      loop: "{{ sliver_protected_packages }}"
+      become: true
+      when:
+        - ansible_os_family == "Debian"
+      failed_when: false
 
     - name: Remove build-time Go installation and caches
       ansible.builtin.file:
@@ -63,30 +71,21 @@
       changed_when: false
       failed_when: false
 
-    - name: Check for unpacked Go compiler
+    - name: Check for unpacked compilers in .sliver directory
       ansible.builtin.stat:
-        path: "{{ sliver_user_home }}/.sliver/go"
-      register: sliver_go_compiler
+        path: "{{ sliver_user_home }}/.sliver/{{ item }}"
+      register: sliver_compilers
+      loop:
+        - go
+        - zig
       become: true
 
-    - name: Remove unpacked Go compiler if found
+    - name: Remove unpacked compilers if found
       ansible.builtin.file:
-        path: "{{ sliver_user_home }}/.sliver/go"
+        path: "{{ item.stat.path }}"
         state: absent
-      when: sliver_go_compiler.stat.exists
-      become: true
-
-    - name: Check for unpacked Zig compiler
-      ansible.builtin.stat:
-        path: "{{ sliver_user_home }}/.sliver/zig"
-      register: sliver_zig_compiler
-      become: true
-
-    - name: Remove unpacked Zig compiler if found
-      ansible.builtin.file:
-        path: "{{ sliver_user_home }}/.sliver/zig"
-        state: absent
-      when: sliver_zig_compiler.stat.exists
+      when: item.stat.exists
+      loop: "{{ sliver_compilers.results }}"
       become: true
 
     - name: Gather package facts
@@ -95,160 +94,121 @@
       when: ansible_os_family == "Debian"
       become: true
 
-    - name: Identify MinGW packages to remove
-      ansible.builtin.set_fact:
-        sliver_mingw_packages_to_remove: "{{ ansible_facts.packages.keys() | select('match', '.*mingw.*|.*w64.*') | reject('match', '.*git.*') | list }}"
-      when:
-        - ansible_os_family == "Debian"
-        - ansible_facts.packages is defined
-
-    - name: Remove MinGW packages
-      ansible.builtin.apt:
-        name: "{{ sliver_mingw_packages_to_remove }}"
-        state: absent
-        purge: true
-      when:
-        - ansible_os_family == "Debian"
-        - sliver_mingw_packages_to_remove is defined
-        - sliver_mingw_packages_to_remove | length > 0
-      become: true
-
-    - name: Remove MinGW directories
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: absent
-      loop: "{{ sliver_mingw_directories }}"
-      become: true
-
-    - name: Remove unnecessary system libraries for containers
-      ansible.builtin.apt:
-        name: "{{ sliver_container_remove_packages }}"
-        state: absent
-        purge: true
-      when:
-        - ansible_os_family == "Debian"
-        - ansible_virtualization_type == "docker"
-      become: true
-      failed_when: false
-
-    - name: Remove development packages
+    - name: Remove development packages (excluding protected)
       ansible.builtin.apt:
         name: "{{ sliver_cleanup_packages_debian }}"
         state: absent
         purge: true
         autoremove: true
-        autoclean: true
       when: ansible_os_family == "Debian"
       become: true
-
-    # Keep the Ansible-native Python cleanup but supplement it
-    - name: Find Python cache directories
-      ansible.builtin.find:
-        paths: /usr
-        patterns: "__pycache__"
-        file_type: directory
-        recurse: true
-      register: sliver_pycache_dirs
-      become: true
       failed_when: false
 
-    - name: Remove Python cache directories
-      ansible.builtin.file:
-        path: "{{ item.path }}"
-        state: absent
-      loop: "{{ sliver_pycache_dirs.files | default([]) }}"
-      become: true
-
-    - name: Find Python compiled files
-      ansible.builtin.find:
-        paths: /usr
-        patterns: "*.pyc"
-        file_type: file
-        recurse: true
-      register: sliver_pyc_files
-      become: true
-      failed_when: false
-
-    - name: Remove Python compiled files
-      ansible.builtin.file:
-        path: "{{ item.path }}"
-        state: absent
-      loop: "{{ sliver_pyc_files.files | default([]) }}"
-      become: true
-
-    - name: Remove pip cache
-      ansible.builtin.file:
-        path: /root/.cache/pip
-        state: absent
-      become: true
-
-    - name: Find log files
-      ansible.builtin.find:
-        paths: /var/log
-        file_type: file
-        recurse: true
-      register: sliver_log_files
-      become: true
-      failed_when: false
-
-    - name: Truncate sliver log files
-      ansible.builtin.copy:
-        content: ""
-        dest: "{{ item.path }}"
-        mode: '0644'
-      loop: "{{ sliver_log_files.files | default([]) }}"
+    - name: Find and remove Python artifacts efficiently
+      ansible.builtin.shell: |
+        # Target specific Python paths
+        for dir in /usr/lib/python* /usr/local/lib/python*; do
+          if [ -d "$dir" ]; then
+            find "$dir" -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+            find "$dir" -type f \( -name "*.pyc" -o -name "*.pyo" \) -delete 2>/dev/null || true
+          fi
+        done
+        # Remove pip cache
+        rm -rf /root/.cache/pip
+        rm -rf /home/*/.cache/pip
+      args:
+        executable: /bin/bash
       become: true
       changed_when: false
+      failed_when: false
 
-    - name: Clean sliver user cache directories
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: absent
-      loop:
-        - "{{ sliver_user_home }}/.cache"
-        - "{{ sliver_user_home }}/.local"
-        - "{{ sliver_user_home }}/.config"
-        - "{{ sliver_user_home }}/.tool-versions"
-      become: true
-
-    - name: Clean root home directories
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: absent
-      loop:
-        - /root/.asdf
-        - /root/.local
-        - /root/.tool-versions
-        - /root/.ssh
-      become: true
-
-    - name: Final cleanup - remove unnecessary items for container image builds
+    - name: Truncate log files
       ansible.builtin.shell: |
-        set -e
+        find /var/log -type f -exec truncate -s 0 {} \; 2>/dev/null || true
+      args:
+        executable: /bin/bash
+      become: true
+      changed_when: false
+      failed_when: false
 
-        echo "=== Starting ultra-aggressive cleanup ==="
+    - name: Container-specific optimizations
+      when: ansible_virtualization_type == "docker"
+      block:
+        - name: Remove container-unnecessary locale data
+          ansible.builtin.shell: |
+            # Keep only C and en_US locales
+            find /usr/share/locale -mindepth 1 -maxdepth 1 ! -name 'en*' -exec rm -rf {} + 2>/dev/null || true
+            # Remove large locale source files
+            rm -rf /usr/share/i18n/locales/cns11643_stroke
+            rm -rf /usr/share/i18n/locales/iso14651_t1_common
+            find /usr/share/i18n -type f -size +1M -delete 2>/dev/null || true
+          args:
+            executable: /bin/bash
+          become: true
+          changed_when: false
+          failed_when: false
 
-        # Remove LLVM and graphics libraries
+        - name: Remove container-unnecessary system files
+          ansible.builtin.file:
+            path: "{{ item }}"
+            state: absent
+          loop:
+            - /usr/share/zoneinfo
+            - /usr/share/doc
+            - /usr/share/man
+            - /usr/share/info
+            - /var/cache/ldconfig
+          become: true
+          failed_when: false
+
+    - name: Targeted cleanup for specific unnecessary packages
+      ansible.builtin.shell: |
+        set -o pipefail
+        echo "=== Starting targeted cleanup for Sliver C2 container ==="
+
+        # Remove ASDF version manager
+        rm -f /usr/local/bin/asdf
+        rm -rf /opt/asdf
+        rm -rf ~/.asdf
+
+        # Remove Python completely if not in protected packages
+        if ! echo "{{ sliver_protected_packages | join(' ') }}" | grep -q python; then
+          apt-get remove -y --purge \
+            python3* libpython3* \
+            python3-pip python3-setuptools python3-wheel \
+            python3-dev python3-venv \
+            2>/dev/null || true
+          rm -rf /usr/lib/python3*
+          rm -rf /usr/lib/*/libpython*
+        fi
+
+        # Remove Perl completely if not in protected packages
+        if ! echo "{{ sliver_protected_packages | join(' ') }}" | grep -q perl; then
+          apt-get remove -y --purge perl perl-base perl-modules-* libperl* 2>/dev/null || true
+          rm -rf /usr/lib/*/perl*
+          rm -rf /usr/share/perl*
+        fi
+
+        # Remove systemd
+        if ! echo "{{ sliver_protected_packages | join(' ') }}" | grep -q systemd; then
+          apt-get remove -y --purge systemd libsystemd* 2>/dev/null || true
+        fi
+
+        # Remove graphics and display libraries
         apt-get remove -y --purge \
           libllvm* llvm* \
-          libgallium* \
-          libvulkan* vulkan* \
-          libgl* libgles* \
-          libdrm* \
-          mesa* \
+          libgallium* libvulkan* vulkan* \
+          libgl* libgles* libdrm* mesa* \
+          libgtk* libgdk* \
+          libasound* libpulse* \
+          libx11-* libxext* libxrender* libxtst* \
           2>/dev/null || true
 
         # Remove snapd
         apt-get remove -y --purge snapd snap-confine ubuntu-core-launcher 2>/dev/null || true
-        rm -rf /usr/lib/snapd
-        rm -rf /snap
-        rm -rf /var/snap
-        rm -rf /var/lib/snapd
+        rm -rf /usr/lib/snapd /snap /var/snap /var/lib/snapd
 
-        # Remove ICU internationalization
-        apt-get remove -y --purge libicu* icu-* 2>/dev/null || true
-
-        # Remove development packages and compilers
+        # Remove development tools (but not runtime libraries)
         apt-get remove -y --purge \
           *-dev *-dbg *-doc \
           gcc* g++* cpp* \
@@ -257,133 +217,34 @@
           manpages manpages-dev \
           2>/dev/null || true
 
-        # Remove GCC
-        rm -rf /usr/libexec/gcc
-        rm -rf /usr/lib/gcc
+        # Clean PostgreSQL development files but keep runtime
+        if echo "{{ sliver_protected_packages | join(' ') }}" | grep -q postgresql; then
+          # Only remove development/documentation files
+          rm -rf /usr/lib/postgresql/*/lib/bitcode
+          rm -rf /usr/lib/postgresql/*/lib/pgxs
+          rm -rf /usr/share/postgresql/*/extension
+          find /usr/lib/postgresql -name "*.bc" -delete 2>/dev/null || true
+        else
+          # Remove PostgreSQL completely if not protected
+          apt-get remove -y --purge postgresql* libpq* 2>/dev/null || true
+        fi
 
-        # Remove Perl
-        apt-get remove -y --purge perl perl-base perl-modules-* 2>/dev/null || true
-        rm -rf /usr/lib/aarch64-linux-gnu/perl*
-        rm -rf /usr/share/perl*
+        # Remove hardware databases
+        rm -rf /usr/lib/udev
+        rm -f /lib/udev/hwdb.bin
 
-        # Remove Python packages
-        apt-get remove -y --purge \
-          python3-pip python3-setuptools python3-wheel \
-          python3-dev python3-venv \
-          2>/dev/null || true
+        # Remove gconv libraries if not needed
+        rm -rf /usr/lib/*/gconv
 
-        # Remove other unnecessary packages
-        apt-get remove -y --purge \
-          openssh-server \
-          krb5-locales \
-          publicsuffix \
-          xauth \
-          fontconfig* fonts-* \
-          libgtk* libgdk* \
-          libasound* libpulse* \
-          libx11-* libxext* libxrender* libxtst* \
-          2>/dev/null || true
-
-        # Clean PostgreSQL - remove bitcode and unnecessary components
-        rm -rf /usr/lib/postgresql/*/lib/bitcode
-        rm -rf /usr/lib/postgresql/*/lib/pgxs
-        rm -rf /usr/share/postgresql/*/extension
-        find /usr/lib/postgresql -name "*.bc" -delete 2>/dev/null || true
-
-        # Remove file magic database
-        rm -f /usr/lib/file/magic.mgc
-
-        # Remove udev hardware database
-        rm -f /usr/lib/udev/hwdb.bin
-
-        # Purge any packages that were automatically installed as dependencies
-        apt-get autoremove -y --purge
-
-        # Mark all libraries as auto-installed and remove unused
-        apt-mark auto ".*" 2>/dev/null || true
-        apt-mark manual git sliver-server sliver-client postgresql postgresql-client postgresql-contrib 2>/dev/null || true
-        apt-get autoremove -y --purge
-
-        # Clean package manager completely
-        apt-get clean
-        apt-get autoclean
-        rm -rf /var/lib/apt/lists/*
-        rm -rf /var/cache/apt/*
-        rm -rf /var/cache/debconf/*
-        rm -rf /var/lib/dpkg/*-old
-        rm -rf /var/lib/dpkg/backup/*
-
-        # Remove all documentation and man pages
-        rm -rf /usr/share/doc
-        rm -rf /usr/share/man
-        rm -rf /usr/share/info
-        rm -rf /usr/share/lintian
-        rm -rf /usr/share/linda
-        rm -rf /usr/share/bug
-
-        # Remove all locales except C
-        rm -rf /usr/share/locale/*
-
-        # Remove misc shared data
-        rm -rf /usr/share/zoneinfo
-        rm -rf /usr/share/i18n
-        rm -rf /usr/share/common-licenses
-        rm -rf /usr/share/mime
-        rm -rf /usr/share/pixmaps
-        rm -rf /usr/share/applications
-        rm -rf /usr/share/menu
-        rm -rf /usr/share/sounds
-        rm -rf /usr/share/icons
-        rm -rf /usr/share/fonts
-        rm -rf /usr/share/terminfo
-        rm -rf /usr/share/X11
-        rm -rf /usr/share/bash-completion
-
-        # Remove all static libraries and headers
+        # Remove static libraries and headers
         find /usr -name "*.a" -delete 2>/dev/null || true
         find /usr -name "*.la" -delete 2>/dev/null || true
         rm -rf /usr/include
 
-        # Remove Python stuff we do not need
-        rm -rf /usr/lib/python*/test
-        rm -rf /usr/lib/python*/tests
-        rm -rf /usr/lib/python*/idle*
-        rm -rf /usr/lib/python*/tkinter
-        rm -rf /usr/lib/python*/unittest
-        rm -rf /usr/lib/python*/ensurepip
-        rm -rf /usr/lib/python*/distutils
-        rm -rf /usr/lib/python*/lib2to3
-        rm -rf /usr/lib/python*/pydoc*
-        rm -rf /usr/lib/python*/config-*
-        find /usr -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
-        find /usr -type f -name "*.pyc" -delete 2>/dev/null || true
-        find /usr -type f -name "*.pyo" -delete 2>/dev/null || true
+        # Final autoremove
+        apt-get autoremove -y --purge
 
-        # Clean all caches
-        rm -rf /var/cache/*
-        rm -rf /root/.cache
-        rm -rf /root/.local
-        rm -rf /root/.config
-        rm -rf /home/*/.cache
-        rm -rf /home/*/.local
-        rm -rf /home/*/.config
-
-        # Clean tmp
-        rm -rf /tmp/* /var/tmp/*
-
-        # Remove all logs
-        find /var/log -type f -delete 2>/dev/null || true
-
-        # Remove cron, systemd catalog, etc
-        rm -rf /var/spool/cron
-        rm -rf /var/spool/mail
-        rm -rf /var/lib/systemd/catalog
-
-        # Cleanup any remaining build artifacts
-        find / -name "*.o" -delete 2>/dev/null || true
-        find / -name "*.lo" -delete 2>/dev/null || true
-
-        echo "=== Cleanup complete ==="
+        echo "=== Targeted cleanup complete ==="
       args:
         executable: /bin/bash
       become: true
@@ -391,9 +252,57 @@
       failed_when: false
       changed_when: false
 
-    - name: Unhold git package after cleanup is complete
-      ansible.builtin.dpkg_selections:
-        name: git
-        selection: install
+    - name: Clean all cache directories once
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ (sliver_cleanup_paths + sliver_additional_cleanup_paths | default([])) | unique }}"
+      become: true
+
+    - name: Verify sliver binaries still work after cleanup
+      ansible.builtin.command:
+        cmd: "{{ sliver_install_path }}/{{ item }} version"
+      loop: "{{ sliver_keep_binaries }}"
+      register: sliver_binary_check
+      failed_when: false
+      become: true
+      changed_when: false
+
+    - name: Report binary verification results
+      ansible.builtin.debug:
+        msg: "Binary {{ item.item }} check: {{ 'OK' if item.rc == 0 else 'FAILED' }}"
+      loop: "{{ sliver_binary_check.results }}"
+      when: sliver_binary_check is defined
+
+    - name: Final APT cleanup (last for layer caching)
+      ansible.builtin.shell: |  # noqa: command-instead-of-module
+        set -o pipefail
+        apt-get clean
+        apt-get autoclean
+        rm -rf /var/lib/apt/lists/*
+        rm -rf /var/cache/apt/*
+        rm -rf /var/lib/dpkg/*-old
+        rm -rf /var/lib/dpkg/backup/*
+      args:
+        executable: /bin/bash
       become: true
       when: ansible_os_family == "Debian"
+      changed_when: false
+
+    - name: Unhold protected packages after cleanup
+      ansible.builtin.dpkg_selections:
+        name: "{{ item }}"
+        selection: install
+      loop: "{{ sliver_protected_packages }}"
+      become: true
+      when: ansible_os_family == "Debian"
+      failed_when: false
+
+- name: Display cleanup summary
+  ansible.builtin.debug:
+    msg:
+      - "=== Sliver Cleanup Complete ==="
+      - "Protected packages: {{ sliver_protected_packages | length }}"
+      - "Binaries verified: {{ sliver_keep_binaries | join(', ') }}"
+      - "All binaries functional: {{ sliver_binary_check.results | selectattr('rc', 'equalto', 0) | list | length == sliver_keep_binaries | length }}"
+  when: sliver_binary_check is defined

--- a/roles/sliver/tasks/setup.yml
+++ b/roles/sliver/tasks/setup.yml
@@ -42,12 +42,22 @@
     mode: '0644'
   when: sliver_asdf_plugins | selectattr('name', 'equalto', 'golang') | list | length > 0
 
-- name: Add sliver_install_path to $PATH
-  ansible.builtin.lineinfile:
+- name: Add Sliver paths to user's bashrc
+  ansible.builtin.blockinfile:
     path: "{{ sliver_user_home }}/.bashrc"
-    line: "export PATH=$PATH:{{ sliver_install_path }}"
-    insertafter: EOF
-    regexp: "^export PATH=.*:{{ sliver_install_path }}.*$"
+    block: |
+      # Sliver paths
+      export PATH="/opt/sliver:$PATH"
+
+      # Add Sliver's Go and tools to PATH (created on first server run)
+      if [ -d "{{ sliver_user_home }}/.sliver/go/bin" ]; then
+        export PATH="{{ sliver_user_home }}/.sliver/go/bin:$PATH"
+      fi
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - SLIVER PATHS"
+    create: true
+    owner: "{{ sliver_username }}"
+    group: "{{ sliver_usergroup }}"
+    mode: '0644'
   become: true
   become_user: "{{ sliver_username }}"
 
@@ -175,6 +185,7 @@
   when:
     - not sliver_server_unpacked_stat.stat.exists
     - sliver_server_exists_for_unpack.stat.exists
+    - sliver_unpack_at_build | default(true) | bool
   changed_when: "'Unpacking complete' in sliver_unpack_result.stdout"
   register: sliver_unpack_result
   environment:

--- a/roles/sliver/vars/main.yml
+++ b/roles/sliver/vars/main.yml
@@ -36,6 +36,7 @@ sliver_debian_packages:
   - nasm
   - ncurses-dev
   - openssl
+  - patch
   - postgresql
   - postgresql-contrib
   - postgresql-client

--- a/roles/sliver/vars/main.yml
+++ b/roles/sliver/vars/main.yml
@@ -97,17 +97,6 @@ sliver_cleanup_paths:
   - "/root/.tool-versions"
   - "/root/.ssh"
 
-sliver_system_cleanup_paths:
-  - /var/lib/apt/lists/*
-  - /var/cache/apt/*
-  - /var/cache/debconf/*
-  - /usr/share/doc/*
-  - /usr/share/man/*
-  - /usr/share/locale/*
-  - /usr/share/info/*
-  - /tmp/*
-  - /var/tmp/*
-
 sliver_mingw_directories:
   - /usr/x86_64-w64-mingw32
   - /usr/i686-w64-mingw32

--- a/roles/sliver/vars/main.yml
+++ b/roles/sliver/vars/main.yml
@@ -1,48 +1,75 @@
 ---
-sliver_common_install_packages:
-  - acl
-  - git
-  - gnupg
-  - make
-  - wget
-  - unzip
-  - zip
+sliver_packages:
+  # Packages to keep after build
+  essential:
+    - acl
+    - git
+    - gnupg
+    - unzip
+    - zip
 
-sliver_debian_packages:
-  - apt-utils
-  - autoconf
-  - build-essential
-  - binutils-mingw-w64
-  - bison
-  - curl
-  - g++-mingw-w64
-  - gpg
-  - libapr1
-  - libcurl4-openssl-dev
-  - libgmp3-dev
-  - libpcap-dev
-  - libpq-dev
-  - libsqlite3-dev
-  - libsvn1
-  - libssl-dev
-  - libtool
-  - libxml2
-  - libxml2-dev
-  - libxslt-dev
-  - libyaml-dev
-  - locate
-  - make
-  - mingw-w64
-  - nasm
-  - ncurses-dev
-  - openssl
-  - patch
-  - postgresql
-  - postgresql-contrib
-  - postgresql-client
-  - xsel
-  - zlib1g
-  - zlib1g-dev
+  # Packages needed for build but removed during cleanup
+  build_only:
+    - make
+    - wget
+    - curl
+    - autoconf
+    - automake
+    - build-essential
+    - gcc
+    - g++
+    - libtool
+    - python3-pip
+    - ansible
+    - libssl-dev
+    - zlib1g-dev
+    - libncurses5-dev
+    - libncursesw5-dev
+    - libreadline-dev
+    - libsqlite3-dev
+    - libgdbm-dev
+    - libdb5.3-dev
+    - libbz2-dev
+    - libexpat1-dev
+    - liblzma-dev
+    - libffi-dev
+
+  # Packages that stay installed (runtime dependencies)
+  runtime_debian:
+    - apt-utils
+    - gpg
+    - openssl
+    - libapr1
+    - libsvn1
+    - libxml2
+    - zlib1g
+    - xsel
+    - libcurl4-openssl-dev
+    - libgmp3-dev
+    - libpcap-dev
+    - libpq-dev
+    - libxml2-dev
+    - libxslt-dev
+    - libyaml-dev
+    - ncurses-dev
+    - postgresql
+    - postgresql-contrib
+    - postgresql-client
+
+  # Cross-compilation tools (always removed during cleanup)
+  cross_compile:
+    - binutils-mingw-w64
+    - g++-mingw-w64
+    - mingw-w64
+    - bison
+    - nasm
+    - locate
+    - patch
+
+# Compose installation lists
+sliver_common_install_packages: "{{ sliver_packages.essential + ['make', 'wget', 'curl'] }}"
+
+sliver_debian_packages: "{{ sliver_packages.build_only + sliver_packages.runtime_debian + sliver_packages.cross_compile }}"
 
 sliver_el_packages:
   - epel-release
@@ -51,3 +78,61 @@ sliver_el_packages:
   - protobuf
   - zlib
   - zlib-devel
+
+# Cleanup lists (reference the same packages)
+sliver_cleanup_packages_debian: "{{ sliver_packages.build_only + sliver_packages.cross_compile }}"
+
+# Cleanup paths
+sliver_cleanup_paths:
+  - "{{ sliver_user_home }}/go"
+  - "{{ sliver_user_home }}/.cache"
+  - "{{ sliver_user_home }}/.asdf"
+  - "{{ sliver_user_home }}/.local"
+  - "{{ sliver_user_home }}/.config"
+  - "{{ sliver_user_home }}/.tool-versions"
+  - "/root/go"
+  - "/root/.cache"
+  - "/root/.asdf"
+  - "/root/.local"
+  - "/root/.tool-versions"
+  - "/root/.ssh"
+
+sliver_system_cleanup_paths:
+  - /var/lib/apt/lists/*
+  - /var/cache/apt/*
+  - /var/cache/debconf/*
+  - /usr/share/doc/*
+  - /usr/share/man/*
+  - /usr/share/locale/*
+  - /usr/share/info/*
+  - /tmp/*
+  - /var/tmp/*
+
+sliver_mingw_directories:
+  - /usr/x86_64-w64-mingw32
+  - /usr/i686-w64-mingw32
+  - /usr/x86_64-w64-mingw32ucrt
+
+sliver_source_directories:
+  - client
+  - server
+  - implant
+  - protobuf
+  - util
+  - vendor
+  - test
+  - docs
+  - .github
+  - .git
+
+sliver_keep_binaries:
+  - sliver-server
+  - sliver-client
+
+sliver_container_remove_packages:
+  - "*vulkan*"
+  - "*llvm*"
+  - "libicu*"
+  - "snapd"
+  - "libgallium*"
+  - "libasan*"

--- a/roles/sliver/vars/main.yml
+++ b/roles/sliver/vars/main.yml
@@ -3,9 +3,16 @@ sliver_packages:
   # Packages to keep after build
   essential:
     - acl
+    - ca-certificates
     - git
     - gnupg
+    - libcurl4
+    - libssl3
+    - libxml2
     - unzip
+    - vim
+    - vim-common
+    - vim-runtime
     - zip
 
   # Packages needed for build but removed during cleanup
@@ -96,6 +103,12 @@ sliver_cleanup_paths:
   - "/root/.local"
   - "/root/.tool-versions"
   - "/root/.ssh"
+  - "/tmp/*"
+  - "/var/tmp/*"
+  - "/var/cache/debconf"
+  - "/var/lib/systemd/catalog"
+  - "/var/spool/cron"
+  - "/var/spool/mail"
 
 sliver_mingw_directories:
   - /usr/x86_64-w64-mingw32


### PR DESCRIPTION
**Key Changes:**

- Replaced discrete cleanup steps with a unified, aggressive shell script for 
image minimization
- Introduced structured package variables and granular cleanup/control in 
Ansible tasks
- Refactored cleanup.yml to use Ansible modules for safety and maintainability
- Modernized environment setup and documentation for improved clarity and 
future-proofing

**Added:**

- Structured package dictionary (`sliver_packages`) categorizing essential, 
build-only, runtime, and cross-compile dependencies for maintainable installs 
and removals (`vars/main.yml`, `README.md`)
- Composed variables for cleanup paths, MinGW directories, source directories, 
binaries to keep, and container-specific removals to streamline references in 
tasks and ensure comprehensive cleanup
- New Ansible cleanup steps in `cleanup.yml` to:
  - Remove non-binary files, source and build directories, and Python 
caches/compiled files
  - Strip binaries, truncate logs, and clean user/root home directories
  - Hold/unhold git during package cleanup to prevent accidental removal on 
Debian
- Fact gathering and dynamic package removal for MinGW and container-only 
packages
- `sliver_unpack_at_build` variable for build-time unpack control

**Changed:**

- Replaced legacy flat package lists with structured, categorized lists and 
derived install/cleanup variables in `vars/main.yml`
- Refactored `cleanup.yml` to use Ansible modules for file, package, and cache 
operations, improving idempotence and safety
- Consolidated all file, package, and log cleanup into a single aggressive 
shell script for final image slimming in container builds
- Updated bashrc path handling to use an Ansible block, supporting future path 
additions and Sliver/Go tools (`setup.yml`)
- Made sliver unpack conditional on `sliver_unpack_at_build` for flexible 
container builds
- Updated Go version default and expanded documentation in `README.md` for new 
variables and cleanup steps

**Removed:**

- Legacy flat package lists and associated references in favor of the new 
`sliver_packages` structure
- Discrete file, log, and package cleanup steps (including PostgreSQL log 
handling, looping over cleanup paths, and manual stat checks) now handled by 
shell script and Ansible-native tasks
- Single-line $PATH append in favor of block-based approach for environment 
management
- Redundant or unsafe shell-based cleanup tasks replaced with safer, 
declarative Ansible methods