### PR TITLE
refactor: improve cleanup logic for python and apt in sliver role

### DIFF
--- a/roles/sliver/README.md
+++ b/roles/sliver/README.md
@@ -181,7 +181,8 @@ Install sliver c2
 - **Remove container-unnecessary locale data** (ansible.builtin.shell)
 - **Remove container-unnecessary system files** (ansible.builtin.shell)
 - **Targeted cleanup for specific unnecessary packages** (ansible.builtin.shell) - Conditional
-- **Final APT cleanup (last for layer caching)** (ansible.builtin.shell) - Conditional
+- **Final APT cleanup** (ansible.builtin.apt) - Conditional
+- **Clean APT cache and lists** (ansible.builtin.shell) - Conditional
 - **Unhold protected packages after cleanup** (ansible.builtin.shell) - Conditional
 - **Display cleanup summary** (ansible.builtin.debug) - Conditional
 

--- a/roles/sliver/tasks/cleanup.yml
+++ b/roles/sliver/tasks/cleanup.yml
@@ -4,7 +4,7 @@
   block:
     - name: Create list of packages to protect
       ansible.builtin.set_fact:
-        sliver_protected_packages: "{{ (sliver_packages.essential | default([])) + (sliver_packages.runtime_debian | default([])) | unique }}"
+        sliver_protected_packages: "{{ (sliver_packages.essential | default([])) + (sliver_packages.runtime_debian | default([])) + ['python3', 'python3-minimal', 'libpython3-stdlib', 'python3-apt'] | unique }}"
       when: ansible_os_family == "Debian"
 
     - name: Hold runtime and essential packages before cleanup
@@ -123,11 +123,14 @@
 
     - name: Find and remove Python artifacts efficiently
       ansible.builtin.shell: |
-        # Target specific Python paths
+        set -o pipefail
+        # Target specific Python paths but keep core Python
         for dir in /usr/lib/python* /usr/local/lib/python*; do
           if [ -d "$dir" ]; then
             find "$dir" -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
             find "$dir" -type f \( -name "*.pyc" -o -name "*.pyo" \) -delete 2>/dev/null || true
+            # Remove test directories but keep core modules
+            find "$dir" -type d \( -name "test" -o -name "tests" -o -name "idle_test" \) -exec rm -rf {} + 2>/dev/null || true
           fi
         done
         # Remove pip cache
@@ -183,6 +186,9 @@
         set -o pipefail
         echo "=== Starting targeted cleanup for Sliver C2 container ==="
 
+        # Always protect Python3 for Ansible
+        PYTHON_PROTECTED="python3 python3-minimal libpython3-stdlib python3-apt"
+
         # Remove ASDF version manager
         rm -f /usr/local/bin/asdf
         rm -rf /opt/asdf
@@ -193,16 +199,19 @@
         rm -rf /tmp/* /var/tmp/*
         rm -rf /var/cache/debconf /var/lib/systemd/catalog /var/spool/cron /var/spool/mail
 
-        # Remove Python completely if not in protected packages
-        if ! echo "{{ sliver_protected_packages | join(' ') }}" | grep -q python; then
-          apt-get remove -y --purge \
-            python3* libpython3* \
-            python3-pip python3-setuptools python3-wheel \
-            python3-dev python3-venv \
-            2>/dev/null || true
-          rm -rf /usr/lib/python3*
-          rm -rf /usr/lib/*/libpython*
-        fi
+        # Remove only Python development packages, not core Python
+        apt-get remove -y --purge \
+          python3-dev python3-venv python3-pip python3-setuptools python3-wheel \
+          python3-distutils python3-lib2to3 \
+          2>/dev/null || true
+
+        # Clean up Python but keep core modules
+        find /usr/lib/python3* -type d \( -name "dist-packages" -o -name "site-packages" \) -exec sh -c '
+          for dir; do
+            # Keep only essential packages including apt and encodings
+            find "$dir" -mindepth 1 -maxdepth 1 -type d ! \( -name "apt*" -o -name "encodings" -o -name "urllib*" -o -name "json" -o -name "importlib*" -o -name "collections*" \) -exec rm -rf {} + 2>/dev/null || true
+          done
+        ' sh {} +
 
         # Remove Perl completely if not in protected packages
         if ! echo "{{ sliver_protected_packages | join(' ') }}" | grep -q perl; then
@@ -274,11 +283,18 @@
       failed_when: false
       changed_when: false
 
-    - name: Final APT cleanup (last for layer caching)
-      ansible.builtin.shell: |  # noqa: command-instead-of-module
-        set -o pipefail
-        apt-get clean
-        apt-get autoclean
+    - name: Final APT cleanup
+      ansible.builtin.apt:
+        autoclean: yes
+        autoremove: yes
+        clean: yes
+      become: true
+      when: ansible_os_family == "Debian"
+      changed_when: false
+      failed_when: false
+
+    - name: Clean APT cache and lists
+      ansible.builtin.shell: |
         rm -rf /var/lib/apt/lists/*
         rm -rf /var/cache/apt/*
         rm -rf /var/lib/dpkg/*-old


### PR DESCRIPTION
**Added:**

- Add separate task to clean APT cache and lists after final cleanup
- Explicitly include core python packages in protected list to prevent accidental
  removal

**Changed:**

- Switch final APT cleanup to use `ansible.builtin.apt` module with autoclean, autoremove, and clean options for reliability and idempotence
- Update python artifact removal to also delete test directories and ensure core modules are retained
- Refine targeted package removal: remove only python development and extra packages, keep core python, and selectively clean site/dist-packages while preserving essentials
- Update documentation to reflect refined cleanup steps and clarify use of modules and conditional logic

**Removed:**

- Remove unconditional python package purge logic that could break Ansible by removing required python packages