### PR TITLE
ci: enable automerge for major dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,6 +41,7 @@
       automerge: true,
       automergeType: 'pr',
       matchUpdateTypes: [
+        'major',
         'minor',
         'patch',
       ],


### PR DESCRIPTION
**Key Changes:**

- Expanded Renovate automerge eligibility to include major dependency updates
- Preserved the existing pull request-based automerge flow for dependency upgrades
- Aligned automerge behavior across major, minor, and patch update types

**Changed:**

- Renovate dependency update automation now includes major updates in the automerge match criteria, allowing eligible major version PRs to be automatically merged using the existing configuration - .github/renovate.json5