### PR TITLE
fix: add roles table markers to README so pre-commit hook passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ ansible-galaxy collection build --force && \
 
 ## Roles
 
+<!-- ROLES TABLE START -->
+
+| Role | Description |
+| ---- | ----------- |
+| [`attack_box`](roles/attack_box/README.md) | Creates an attack box for penetration testing and red teaming |
+| [`recon_toolkit`](roles/recon_toolkit/README.md) | Install reconnaissance tools for subdomain enumeration, HTTP discovery, web crawling, vulnerability scanning, and parameter analysis |
+| [`sliver`](roles/sliver/README.md) | Install sliver c2 |
+| [`ttpforge`](roles/ttpforge/README.md) | \| |
+
+<!-- ROLES TABLE END -->
+
 ### Sliver
 
 Installs and configures [Sliver](https://github.com/BishopFox/sliver), a


### PR DESCRIPTION
**Key Changes:**

- Restored a green pre-commit run on every PR by giving the `update-architecture-diagram` hook the README.md markers it expects after the template sync
- Auto-populated the roles table block under the existing `## Roles` section, leaving the hand-written `### Sliver`/`### TTPForge`/`### Attack Box` notes intact
- Unblocks #704 (and any other PR opened against `main`) without touching the synced hook script

**Added:**

- Roles table markers in `README.md` - Inserted `<!-- ROLES TABLE START -->` and `<!-- ROLES TABLE END -->` under `## Roles` and let `.hooks/gen-arch-diagram.py` fill in the generated rows for `attack_box`, `recon_toolkit`, `sliver`, and `ttpforge` between them