### PR TITLE
fix: add boolean-safe create/destroy playbooks to recon_toolkit molecule scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ ansible-galaxy collection build --force && \
 
 ## Roles
 
+<!-- ROLES TABLE START -->
+
+| Role | Description |
+| ---- | ----------- |
+| [`attack_box`](roles/attack_box/README.md) | Creates an attack box for penetration testing and red teaming |
+| [`recon_toolkit`](roles/recon_toolkit/README.md) | Install reconnaissance tools for subdomain enumeration, HTTP discovery, web crawling, vulnerability scanning, and parameter analysis |
+| [`sliver`](roles/sliver/README.md) | Install sliver c2 |
+| [`ttpforge`](roles/ttpforge/README.md) | \| |
+
+<!-- ROLES TABLE END -->
+
 ### Sliver
 
 Installs and configures [Sliver](https://github.com/BishopFox/sliver), a

--- a/roles/recon_toolkit/molecule/default/create.yml
+++ b/roles/recon_toolkit/molecule/default/create.yml
@@ -1,0 +1,41 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    molecule_labels:
+      owner: molecule
+  tasks:
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        recon_toolkit_ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: lookup('env', 'HOME') | length > 0
+
+    - name: Create molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
+        image: "{{ item.image }}"
+        command: "{{ item.command | default('') }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
+      register: recon_toolkit_server
+      loop: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: recon_toolkit_docker_jobs
+      until: recon_toolkit_docker_jobs.finished
+      retries: 300
+      delay: 1
+      loop: "{{ recon_toolkit_server.results }}"

--- a/roles/recon_toolkit/molecule/default/destroy.yml
+++ b/roles/recon_toolkit/molecule/default/destroy.yml
@@ -1,0 +1,14 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+      when: molecule_yml.platforms is defined


### PR DESCRIPTION
**Key Changes:**

- Made `Role Test - recon_toolkit` green again under `ansible-core` 2.21 by stopping the scenario from inheriting `molecule_docker`'s bundled `create.yml` / `destroy.yml`, which guard the async-dir setup with `when: lookup('env', 'HOME')` — a string conditional that 2.21 now rejects with `A 'when' expression failed: Conditional result (True) was derived from value of type 'str'`
- Surfaced on #704 (and every PR since the toolchain bumped to Python 3.14 / ansible-core 2.21); the other roles in this collection were already immune because they ship scenario-local playbooks with a boolean conditional
- Stacked on top of #705 so the `update-architecture-diagram` pre-commit hook can run; once #705 merges this branch will rebase down to just the two new files

**Added:**

- `roles/recon_toolkit/molecule/default/create.yml` - Mirrors the `attack_box` / `sliver` / `ttpforge` create playbook, but uses `lookup('env', 'HOME') | length > 0` so the `when` clause is a proper boolean and stays compatible with `ansible-core` 2.21+
- `roles/recon_toolkit/molecule/default/destroy.yml` - Identical to the destroy playbook used by the other roles, replacing the buggy bundled `molecule_docker/playbooks/destroy.yml`