### PR TITLE
fix: simplify sliver git change detection and harden mise path

### DIFF
--- a/playbooks/recon_toolkit/molecule/default/create.yml
+++ b/playbooks/recon_toolkit/molecule/default/create.yml
@@ -1,0 +1,41 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    molecule_labels:
+      owner: molecule
+  tasks:
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        recon_toolkit_ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: lookup('env', 'HOME') | length > 0
+
+    - name: Create molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
+        image: "{{ item.image }}"
+        command: "{{ item.command | default('') }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
+      register: recon_toolkit_server
+      loop: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: recon_toolkit_docker_jobs
+      until: recon_toolkit_docker_jobs.finished
+      retries: 300
+      delay: 1
+      loop: "{{ recon_toolkit_server.results }}"

--- a/playbooks/recon_toolkit/molecule/default/destroy.yml
+++ b/playbooks/recon_toolkit/molecule/default/destroy.yml
@@ -1,0 +1,14 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+      when: molecule_yml.platforms is defined

--- a/roles/sliver/README.md
+++ b/roles/sliver/README.md
@@ -175,7 +175,6 @@ Install sliver c2
 
 
 - **Configure Git to allow sliver_install_path as a safe directory** (community.general.git_config)
-- **Get current Sliver repo HEAD** (ansible.builtin.command)
 - **Clone Sliver repo** (ansible.builtin.git)
 - **Check current ownership of {{ sliver_install_path }}** (ansible.builtin.stat)
 - **Ensure correct ownership of the Sliver repository** (ansible.builtin.file) - Conditional

--- a/roles/sliver/tasks/setup.yml
+++ b/roles/sliver/tasks/setup.yml
@@ -6,15 +6,6 @@
     value: "{{ sliver_install_path }}"
   become: true
 
-- name: Get current Sliver repo HEAD
-  ansible.builtin.command:
-    cmd: git rev-parse HEAD
-    chdir: "{{ sliver_install_path }}"
-  become: true
-  register: sliver_repo_head_before
-  changed_when: false
-  failed_when: false
-
 - name: Clone Sliver repo
   ansible.builtin.git:
     repo: 'https://github.com/bishopfox/sliver.git'
@@ -23,7 +14,7 @@
     force: true
   become: true
   register: sliver_git_result
-  changed_when: sliver_repo_head_before.rc != 0 or sliver_git_result.before != sliver_git_result.after
+  changed_when: sliver_git_result.before is none or sliver_git_result.before != sliver_git_result.after
 
 - name: Check current ownership of {{ sliver_install_path }}
   ansible.builtin.stat:
@@ -56,7 +47,7 @@
 
 - name: Trust mise config in Sliver directory
   ansible.builtin.command:
-    cmd: mise trust "{{ sliver_install_path }}/.mise.toml"
+    cmd: /usr/local/bin/mise trust "{{ sliver_install_path }}/.mise.toml"
   become: true
   become_user: "{{ sliver_username }}"
   environment:

--- a/roles/ttpforge/tasks/setup.yml
+++ b/roles/ttpforge/tasks/setup.yml
@@ -47,7 +47,7 @@
 
 - name: Trust mise config in ttpforge directory
   ansible.builtin.command:
-    cmd: mise trust "{{ ttpforge_install_path }}/.mise.toml"
+    cmd: /usr/local/bin/mise trust "{{ ttpforge_install_path }}/.mise.toml"
   become: true
   become_user: "{{ ttpforge_username }}"
   environment:


### PR DESCRIPTION
**Key Changes:**

- Replaced fragile pre-clone HEAD check with native `ansible.builtin.git` module change detection for sliver role
- Hardcoded absolute path for `mise` binary in both sliver and ttpforge roles to prevent PATH resolution failures
- Added molecule test scaffolding for the recon_toolkit playbook

**Added:**

- Molecule test lifecycle playbooks for recon_toolkit - `create.yml` handles async Docker container creation with label support, and `destroy.yml` handles container teardown across all defined platforms

**Changed:**

- Git change detection logic in sliver role - removed the pre-clone `git rev-parse HEAD` command and replaced the `changed_when` condition with a check against `sliver_git_result.before is none or sliver_git_result.before != sliver_git_result.after`, relying entirely on the git module's built-in before/after tracking
- `mise trust` command in both sliver and ttpforge roles - changed from `mise trust` to `/usr/local/bin/mise trust` to ensure the binary is found regardless of the executing user's PATH environment

**Removed:**

- Pre-clone HEAD capture task in sliver role - eliminated the `Get current Sliver repo HEAD` command task and its `sliver_repo_head_before` registered variable, simplifying the setup flow and removing a task that could silently fail on first install