### PR TITLE
ci: streamline template-sync trigger and scope workflow files to renovate

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -13,19 +13,14 @@ on:
         default: "debug"
         required: false
 
-  schedule:
-    # Run on the 1st of every month at 00:00 UTC
-    - cron: "0 0 1 * *"
+  # Fan-out from CowDogMoo/ansible-collection-workstation's Template Sync
+  # Dispatch workflow; fires within minutes of a template change there.
+  repository_dispatch:
+    types: [template-sync]
 
-  push:
-    branches: ["main"]
-    paths:
-      - '.github/**'
-      - '.hooks/**'
-      - '.pre-commit-config.yaml'
-      - '.mdlrc'
-      - '.editorconfig'
-      - 'Taskfile.yaml'
+  schedule:
+    # Monthly safety net in case a dispatch event is missed.
+    - cron: "0 0 1 * *"
 
 concurrency:
   cancel-in-progress: true
@@ -64,12 +59,12 @@ jobs:
           pr_body: |
             🤖 A new version of the ansible collection template files is available.
 
-            This PR was automatically created to sync the following:
-            - GitHub Actions workflows
-            - Pre-commit hooks and configurations
-            - Ansible-lint configurations
-            - Task definitions
-            - Editor configs and linter rules
+            This PR was automatically created to sync shared infrastructure:
+            - Pre-commit hooks (`.hooks/**`, `.pre-commit-config.yaml`)
+            - Task definitions (`Taskfile.yaml`)
+            - Editor configs (`.editorconfig`)
+
+            Workflow files are managed by Renovate and excluded from this sync.
 
             Please review the changes carefully before merging.
           source_repo_path: CowDogMoo/ansible-collection-workstation

--- a/.templatesyncignore
+++ b/.templatesyncignore
@@ -14,7 +14,5 @@ requirements.yml
 .github/renovate.json5
 .github/labeler.yaml
 .github/labels.yaml
-# All workflow files are ceded to Renovate; template-sync no longer touches them.
 .github/workflows/*
-# Generated per-collection diagram — never propagate workstation's copy.
 arch-diagram/collection_mermaid.md

--- a/.templatesyncignore
+++ b/.templatesyncignore
@@ -14,6 +14,7 @@ requirements.yml
 .github/renovate.json5
 .github/labeler.yaml
 .github/labels.yaml
-.github/workflows/release.yaml
-.github/workflows/molecule.yaml
+# All workflow files are ceded to Renovate; template-sync no longer touches them.
+.github/workflows/*
+# Generated per-collection diagram — never propagate workstation's copy.
 arch-diagram/collection_mermaid.md


### PR DESCRIPTION
**Key Changes:**

- Replaced push-based trigger with `repository_dispatch` for near-real-time sync when the upstream template changes
- Removed GitHub Actions workflows from template-sync scope, delegating them entirely to Renovate
- Updated `.templatesyncignore` to exclude all workflow files with a wildcard instead of listing them individually

**Changed:**

- Sync trigger strategy - Removed the `push` trigger (which fired on changes to `.github/**`, `.hooks/**`, etc.) and replaced it with a `repository_dispatch` event of type `template-sync`, fired from the upstream `CowDogMoo/ansible-collection-workstation` template; the monthly `cron` schedule is retained as a safety net in case a dispatch event is missed
- PR body messaging - Updated the auto-generated PR description to accurately reflect the narrowed sync scope (pre-commit hooks, task definitions, editor configs) and explicitly notes that workflow files are managed by Renovate and excluded from this sync

**Removed:**

- Per-workflow ignore entries - Replaced individual `.github/workflows/release.yaml` and `.github/workflows/molecule.yaml` exclusions in `.templatesyncignore` with a single `.github/workflows/*` wildcard, along with an explanatory comment; also added a comment excluding the per-collection `arch-diagram/collection_mermaid.md` from propagation