### PR TITLE
fix: add dpkg and apt repair tasks before sliver package install

### DIFF
--- a/roles/sliver/README.md
+++ b/roles/sliver/README.md
@@ -158,6 +158,8 @@ Install sliver c2
 ### main.yml
 
 
+- **Recover from interrupted dpkg state** (ansible.builtin.command) - Conditional
+- **Repair broken apt dependencies before bulk install** (ansible.builtin.apt) - Conditional
 - **Install required packages for Sliver** (ansible.builtin.include_role)
 - **Create user** (ansible.builtin.include_role)
 - **Set sliver user home directory** (ansible.builtin.include_tasks)

--- a/roles/sliver/tasks/main.yml
+++ b/roles/sliver/tasks/main.yml
@@ -1,4 +1,24 @@
 ---
+# Rolling-release base images (Kali, Ubuntu-latest) periodically ship with
+# half-configured dpkg state or transitive apt deps that can't be resolved
+# until apt-get -f install runs. Recover that state before invoking the
+# package_management role so the bulk install isn't the first thing apt sees.
+- name: Recover from interrupted dpkg state
+  ansible.builtin.command: dpkg --configure -a
+  become: true
+  changed_when: false
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Repair broken apt dependencies before bulk install
+  ansible.builtin.apt:
+    name: '*'
+    state: fixed
+    update_cache: true
+  become: true
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+  when: ansible_facts['os_family'] == 'Debian'
+
 - name: Install required packages for Sliver
   ansible.builtin.include_role:
     name: cowdogmoo.workstation.package_management


### PR DESCRIPTION
**Key Changes:**

- Added pre-flight dpkg and apt repair steps to handle broken package states on rolling-release distros before bulk installation
- Prevents failures caused by half-configured dpkg state or unresolvable transitive apt dependencies on Kali and Ubuntu-latest base images
- Updated README to reflect the two new conditional tasks in the task execution order

**Added:**

- Pre-flight package state recovery - Added two conditional tasks in `roles/sliver/tasks/main.yml` that run only on Debian-family systems: `dpkg --configure -a` to recover interrupted dpkg state, and `apt-get -f install` (via `state: fixed`) to resolve broken dependencies before the bulk package install begins
- README documentation - Updated `roles/sliver/README.md` to list the two new tasks with their conditionals in the `main.yml` task reference section