### PR TITLE
chore: enable major version automerge in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -54,6 +54,7 @@
       automerge: true,
       automergeType: 'pr',
       matchUpdateTypes: [
+        'major',
         'minor',
         'patch',
       ],


### PR DESCRIPTION
**Key Changes:**

- Expanded Renovate automerge policy to include major version updates
- Minor change to a single configuration entry with broad dependency management implications

**Changed:**

- Automerge update types - Added `major` to the list of allowed automerge update types in `.github/renovate.json5`, allowing major version dependency bumps to be automatically merged alongside existing minor and patch updates