### PR TITLE
feat: add acl_tools role for active directory acl exploitation

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -116,7 +116,7 @@ jobs:
         run: |
           if [[ "${{ steps.check-event.outputs.test_all }}" == "true" ]]; then
             # Test all roles and playbooks
-            MATRIX_JSON='[{"name":"Role Test - attack_box","path":"roles/attack_box"},{"name":"Role Test - mythic","path":"roles/mythic"},{"name":"Role Test - recon_toolkit","path":"roles/recon_toolkit"},{"name":"Role Test - sliver","path":"roles/sliver"},{"name":"Role Test - ttpforge","path":"roles/ttpforge"},{"name":"Playbook Test - atomic-red-team","path":"playbooks/atomic-red-team"},{"name":"Playbook Test - attack_box","path":"playbooks/attack_box"},{"name":"Playbook Test - recon_toolkit","path":"playbooks/recon_toolkit"},{"name":"Playbook Test - sliver","path":"playbooks/sliver"},{"name":"Playbook Test - ttpforge","path":"playbooks/ttpforge"}]'
+            MATRIX_JSON='[{"name":"Role Test - acl_tools","path":"roles/acl_tools"},{"name":"Role Test - attack_box","path":"roles/attack_box"},{"name":"Role Test - mythic","path":"roles/mythic"},{"name":"Role Test - recon_toolkit","path":"roles/recon_toolkit"},{"name":"Role Test - sliver","path":"roles/sliver"},{"name":"Role Test - ttpforge","path":"roles/ttpforge"},{"name":"Playbook Test - atomic-red-team","path":"playbooks/atomic-red-team"},{"name":"Playbook Test - attack_box","path":"playbooks/attack_box"},{"name":"Playbook Test - recon_toolkit","path":"playbooks/recon_toolkit"},{"name":"Playbook Test - sliver","path":"playbooks/sliver"},{"name":"Playbook Test - ttpforge","path":"playbooks/ttpforge"}]'
           else
             # Test only changed roles and playbooks
             ROLES="${{ steps.filter.outputs.roles }}"

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ that I employ regularly.
 graph TD
     Collection[Ansible Collection]
     Collection --> Roles[⚙️ Roles]
-    Roles --> R0[attack_box 🧪]
-    Roles --> R1[mythic 🧪]
+    Roles --> R0[acl_tools 🧪]
+    Roles --> R1[attack_box 🧪]
     Roles --> R2[recon_toolkit 🧪]
     Roles --> R3[sliver 🧪]
     Roles --> R4[ttpforge 🧪]
@@ -53,8 +53,8 @@ ansible-galaxy collection build --force && \
 
 | Role | Description |
 | ---- | ----------- |
+| [`acl_tools`](roles/acl_tools/README.md) | Install and configure Active Directory ACL exploitation tools |
 | [`attack_box`](roles/attack_box/README.md) | Creates an attack box for penetration testing and red teaming |
-| [`mythic`](roles/mythic/README.md) | Install and configure the Mythic C2 framework |
 | [`recon_toolkit`](roles/recon_toolkit/README.md) | Install reconnaissance tools for subdomain enumeration, HTTP discovery, web crawling, vulnerability scanning, and parameter analysis |
 | [`sliver`](roles/sliver/README.md) | Install sliver c2 |
 | [`ttpforge`](roles/ttpforge/README.md) | TTPForge is a Cybersecurity Framework for developing, automating, and executing attacker Tactics, Techniques, and Procedures (TTPs) |

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ graph TD
     Collection --> Roles[⚙️ Roles]
     Roles --> R0[acl_tools 🧪]
     Roles --> R1[attack_box 🧪]
-    Roles --> R2[recon_toolkit 🧪]
-    Roles --> R3[sliver 🧪]
-    Roles --> R4[ttpforge 🧪]
+    Roles --> R2[mythic 🧪]
+    Roles --> R3[recon_toolkit 🧪]
+    Roles --> R4[sliver 🧪]
+    Roles --> R5[ttpforge 🧪]
     Collection --> Playbooks[📚 Playbooks]
     Playbooks --> PB0[atomic-red-team 🧪]
     Playbooks --> PB1[attack_box 🧪]
@@ -55,6 +56,7 @@ ansible-galaxy collection build --force && \
 | ---- | ----------- |
 | [`acl_tools`](roles/acl_tools/README.md) | Install and configure Active Directory ACL exploitation tools |
 | [`attack_box`](roles/attack_box/README.md) | Creates an attack box for penetration testing and red teaming |
+| [`mythic`](roles/mythic/README.md) | Install and configure the Mythic C2 framework |
 | [`recon_toolkit`](roles/recon_toolkit/README.md) | Install reconnaissance tools for subdomain enumeration, HTTP discovery, web crawling, vulnerability scanning, and parameter analysis |
 | [`sliver`](roles/sliver/README.md) | Install sliver c2 |
 | [`ttpforge`](roles/ttpforge/README.md) | TTPForge is a Cybersecurity Framework for developing, automating, and executing attacker Tactics, Techniques, and Procedures (TTPs) |

--- a/roles/acl_tools/README.md
+++ b/roles/acl_tools/README.md
@@ -1,0 +1,126 @@
+<!-- DOCSIBLE START -->
+# acl_tools
+
+## Description
+
+Install and configure Active Directory ACL exploitation tools
+
+## Requirements
+
+- Ansible >= 2.14
+
+## Role Variables
+
+### Default Variables (main.yml)
+
+| Variable | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `acl_tools_ubuntu_packages` | list | <code>&#91;&#93;</code> | No description |
+| `acl_tools_ubuntu_packages.0` | str | <code>git</code> | No description |
+| `acl_tools_ubuntu_packages.1` | str | <code>python3</code> | No description |
+| `acl_tools_ubuntu_packages.2` | str | <code>python3-pip</code> | No description |
+| `acl_tools_ubuntu_packages.3` | str | <code>python3-dev</code> | No description |
+| `acl_tools_ubuntu_packages.4` | str | <code>python3-venv</code> | No description |
+| `acl_tools_ubuntu_packages.5` | str | <code>build-essential</code> | No description |
+| `acl_tools_ubuntu_packages.6` | str | <code>smbclient</code> | No description |
+| `acl_tools_ubuntu_packages.7` | str | <code>samba-common-bin</code> | No description |
+| `acl_tools_install_bloodyad` | bool | <code>True</code> | No description |
+| `acl_tools_bloodyad_package` | str | <code>bloodyAD</code> | No description |
+| `acl_tools_bloodyad_apt_package` | str | <code>bloodyad</code> | No description |
+| `acl_tools_install_pywhisker` | bool | <code>True</code> | No description |
+| `acl_tools_pywhisker_package` | str | <code>pywhisker</code> | No description |
+| `acl_tools_pywhisker_install_dir` | str | <code>/opt/pywhisker</code> | No description |
+| `acl_tools_pyopenssl_package` | str | <code>pyOpenSSL<25</code> | No description |
+| `acl_tools_install_dacledit` | bool | <code>True</code> | No description |
+| `acl_tools_impacket_from_source` | bool | <code>True</code> | No description |
+| `acl_tools_impacket_repo` | str | <code>https://github.com/fortra/impacket.git</code> | No description |
+| `acl_tools_impacket_version` | str | <code>impacket_0_13_0</code> | No description |
+| `acl_tools_impacket_install_dir` | str | <code>/opt/impacket</code> | No description |
+| `acl_tools_install_targetedkerberoast` | bool | <code>True</code> | No description |
+| `acl_tools_targetedkerberoast_repo` | str | <code>https://github.com/ShutdownRepo/targetedKerberoast.git</code> | No description |
+| `acl_tools_targetedkerberoast_install_dir` | str | <code>/opt/targetedKerberoast</code> | No description |
+| `acl_tools_targetedkerberoast_version` | str | <code>main</code> | No description |
+| `acl_tools_update_cache` | bool | <code>True</code> | No description |
+| `acl_tools_pip_break_system_packages` | bool | <code>False</code> | No description |
+| `acl_tools_binaries` | dict | <code>{}</code> | No description |
+| `acl_tools_binaries.bloodyad` | str | <code>/usr/local/bin/bloodyAD</code> | No description |
+| `acl_tools_binaries.pywhisker` | str | <code>/usr/local/bin/pywhisker</code> | No description |
+| `acl_tools_binaries.dacledit` | str | <code>/usr/local/bin/impacket-dacledit</code> | No description |
+| `acl_tools_binaries.targetedkerberoast` | str | <code>/usr/local/bin/targetedKerberoast</code> | No description |
+| `acl_tools_binaries.rpcclient` | str | <code>/usr/bin/rpcclient</code> | No description |
+
+## Tasks
+
+### impacket_source.yml
+
+
+- **Install git for cloning impacket** (ansible.builtin.apt) - Conditional
+- **Remove conflicting apt impacket packages (Ubuntu only - Kali netexec depends on them)** (ansible.builtin.apt) - Conditional
+- **Check if impacket is installed from source** (ansible.builtin.stat)
+- **Check if impacket repo already exists** (ansible.builtin.stat)
+- **Clone impacket repository from GitHub (initial clone)** (ansible.builtin.git) - Conditional
+- **Set impacket venv path** (ansible.builtin.set_fact)
+- **Check if impacket venv exists** (ansible.builtin.stat)
+- **Check if we need to install or reinstall impacket** (ansible.builtin.set_fact)
+- **Create impacket virtual environment** (ansible.builtin.command) - Conditional
+- **Install impacket from source** (ansible.builtin.pip) - Conditional
+- **Check if impacket is correctly installed in venv** (ansible.builtin.command)
+- **Make impacket example scripts executable** (ansible.builtin.shell)
+- **Check if \_\_init\_\_.py exists in impacket/examples** (ansible.builtin.stat)
+- **Create \_\_init\_\_.py in impacket/examples to make it a proper Python package** (ansible.builtin.copy) - Conditional
+- **Check system impacket version (Kali)** (ansible.builtin.command) - Conditional
+- **Install source impacket into system Python (Kali apt netexec needs it system-wide)** (ansible.builtin.pip) - Conditional
+- **Create symlinks for impacket scripts (impacket-* style for Kali compatibility)** (ansible.builtin.shell)
+- **Verify impacket regsecrets module is available** (ansible.builtin.command)
+- **Report impacket installation status** (ansible.builtin.debug)
+
+### linux.yml
+
+
+- **Set DEBIAN_FRONTEND to noninteractive** (ansible.builtin.lineinfile) - Conditional
+- **Update apt cache** (ansible.builtin.apt) - Conditional
+- **Install Ubuntu-compatible dependencies** (ansible.builtin.apt) - Conditional
+- **Check rpcclient availability** (ansible.builtin.command) - Conditional
+- **Install smbclient when rpcclient is missing** (ansible.builtin.apt) - Conditional
+- **Recheck rpcclient availability after smbclient install** (ansible.builtin.command) - Conditional
+- **Check if samba-common-bin package is available** (ansible.builtin.command) - Conditional
+- **Install samba-common-bin when rpcclient is still missing** (ansible.builtin.apt) - Conditional
+- **Install Impacket from source for dacledit** (ansible.builtin.include_tasks) - Conditional
+- **Install bloodyAD via apt (Kali)** (ansible.builtin.apt) - Conditional
+- **Ensure bloodyAD symlink for Kali apt install** (ansible.builtin.file) - Conditional
+- **Check if bloodyAD is already installed** (ansible.builtin.command) - Conditional
+- **Install bloodyAD via pip** (ansible.builtin.pip) - Conditional
+- **Install pywhisker in an isolated virtualenv** (ansible.builtin.pip) - Conditional
+- **Create wrapper script for pywhisker** (ansible.builtin.copy) - Conditional
+- **Clone targetedKerberoast from GitHub** (ansible.builtin.git) - Conditional
+- **Create virtual environment for targetedKerberoast** (ansible.builtin.command) - Conditional
+- **Install targetedKerberoast dependencies in venv** (ansible.builtin.pip) - Conditional
+- **Create wrapper script for targetedKerberoast** (ansible.builtin.copy) - Conditional
+- **Create .py symlink for targetedKerberoast** (ansible.builtin.file) - Conditional
+
+### main.yml
+
+
+- **Include Linux tasks** (ansible.builtin.include_tasks) - Conditional
+
+## Example Playbook
+
+```yaml
+- hosts: servers
+  roles:
+    - acl_tools
+```
+
+## Author Information
+
+- **Author**: Jayson Grace
+- **Company**: techvomit
+- **License**: MIT
+
+## Platforms
+
+
+- Ubuntu: all
+- Debian: all
+- Kali: all
+<!-- DOCSIBLE END -->

--- a/roles/acl_tools/defaults/main.yml
+++ b/roles/acl_tools/defaults/main.yml
@@ -45,8 +45,6 @@ acl_tools_targetedkerberoast_version: "main"
 
 acl_tools_update_cache: true
 
-# Passed as --break-system-packages to pip3 when installing bloodyAD system-wide.
-# Ares wires this to its base role's base_pip_break_required.
 acl_tools_pip_break_system_packages: false
 
 # Tool binary paths (for verification)

--- a/roles/acl_tools/defaults/main.yml
+++ b/roles/acl_tools/defaults/main.yml
@@ -1,0 +1,58 @@
+---
+# ACL exploitation tool packages (Ubuntu-compatible)
+acl_tools_ubuntu_packages:
+  - git
+  - python3
+  - python3-pip
+  - python3-dev
+  - python3-venv
+  - build-essential
+  - smbclient
+  - samba-common-bin
+
+# bloodyAD configuration (ACL exploitation framework)
+acl_tools_install_bloodyad: true
+acl_tools_bloodyad_package: "bloodyAD"
+acl_tools_bloodyad_apt_package: "bloodyad"
+
+# Pywhisker configuration (shadow credentials manipulation)
+acl_tools_install_pywhisker: true
+acl_tools_pywhisker_package: "pywhisker"
+acl_tools_pywhisker_install_dir: "/opt/pywhisker"
+# pywhisker's PFX export calls OpenSSL.crypto.PKCS12, which later pyOpenSSL
+# releases removed — the shadow-cred write lands but the PFX dump crashes with
+# "module 'OpenSSL.crypto' has no attribute 'PKCS12'". The 24.x line still ships
+# PKCS12, so pin below 25. This pin is applied ONLY inside pywhisker's own venv,
+# never to the system interpreter: a system-wide pyOpenSSL<24 references
+# cryptography's _lib.GEN_EMAIL (dropped in cryptography>=42) and crashes every
+# `import OpenSSL`, breaking impacket-ldap/nxc. (certipy shadow uses the
+# cryptography PFX API and is unaffected — it's the preferred path.)
+acl_tools_pyopenssl_package: "pyOpenSSL<25"
+
+# dacledit configuration (Impacket ACL editing)
+acl_tools_install_dacledit: true
+acl_tools_impacket_from_source: true
+acl_tools_impacket_repo: "https://github.com/fortra/impacket.git"
+acl_tools_impacket_version: "impacket_0_13_0"
+acl_tools_impacket_install_dir: "/opt/impacket"
+
+# targetedKerberoast configuration (targeted kerberoasting via ACLs)
+# Reference: https://github.com/ShutdownRepo/targetedKerberoast
+acl_tools_install_targetedkerberoast: true
+acl_tools_targetedkerberoast_repo: "https://github.com/ShutdownRepo/targetedKerberoast.git"
+acl_tools_targetedkerberoast_install_dir: "/opt/targetedKerberoast"
+acl_tools_targetedkerberoast_version: "main"
+
+acl_tools_update_cache: true
+
+# Passed as --break-system-packages to pip3 when installing bloodyAD system-wide.
+# Ares wires this to its base role's base_pip_break_required.
+acl_tools_pip_break_system_packages: false
+
+# Tool binary paths (for verification)
+acl_tools_binaries:
+  bloodyad: "/usr/local/bin/bloodyAD"
+  pywhisker: "/usr/local/bin/pywhisker"
+  dacledit: "/usr/local/bin/impacket-dacledit"
+  targetedkerberoast: "/usr/local/bin/targetedKerberoast"
+  rpcclient: "/usr/bin/rpcclient"

--- a/roles/acl_tools/meta/main.yml
+++ b/roles/acl_tools/meta/main.yml
@@ -1,0 +1,29 @@
+---
+galaxy_info:
+  role_name: acl_tools
+  namespace: l50
+  author: Jayson Grace
+  description: Install and configure Active Directory ACL exploitation tools
+  company: techvomit
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: Kali
+      versions:
+        - all
+  galaxy_tags:
+    - security
+    - pentesting
+    - activedirectory
+    - acl
+    - privesc
+    - kali
+    - offsec
+
+dependencies: []

--- a/roles/acl_tools/molecule/default/callback_plugins/profile_tasks.py
+++ b/roles/acl_tools/molecule/default/callback_plugins/profile_tasks.py
@@ -1,0 +1,29 @@
+# molecule/default/callback_plugins/profile_tasks.py
+from ansible.plugins.callback import CallbackBase
+import time
+
+class CallbackModule(CallbackBase):
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_NAME = 'profile_tasks'
+    CALLBACK_NEEDS_WHITELIST = False
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+        self.stats = {}
+
+    def v2_runner_on_ok(self, result, **kwargs):
+        task_name = result._task.get_name()
+        task_time = time.time() - self.start_time
+        if task_name not in self.stats:
+            self.stats[task_name] = []
+        self.stats[task_name].append(task_time)
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        self.start_time = time.time()
+
+    def v2_playbook_on_stats(self, stats):
+        for task_name, timings in self.stats.items():
+            total_time = sum(timings)
+            average_time = total_time / len(timings)
+            print(f"Task: {task_name} - Total Time: {total_time:.2f}s, Average Time: {average_time:.2f}s")

--- a/roles/acl_tools/molecule/default/converge.yml
+++ b/roles/acl_tools/molecule/default/converge.yml
@@ -1,0 +1,14 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Include default variables
+      ansible.builtin.include_vars:
+        file: "../../defaults/main.yml"
+
+    - name: Include role under test
+      ansible.builtin.include_role:
+        name: l50.arsenal.acl_tools
+      vars:
+        acl_tools_pip_break_system_packages: true

--- a/roles/acl_tools/molecule/default/create.yml
+++ b/roles/acl_tools/molecule/default/create.yml
@@ -1,0 +1,41 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    molecule_labels:
+      owner: molecule
+  tasks:
+    - name: Set async_dir for HOME env # noqa: var-naming[no-role-prefix]
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: lookup('env', 'HOME') | length > 0
+
+    - name: Create molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
+        image: "{{ item.image }}"
+        command: "{{ item.command | default('') }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
+      register: acl_tools_server
+      loop: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: acl_tools_docker_jobs
+      until: acl_tools_docker_jobs.finished
+      retries: 300
+      delay: 1
+      loop: "{{ acl_tools_server.results }}"

--- a/roles/acl_tools/molecule/default/destroy.yml
+++ b/roles/acl_tools/molecule/default/destroy.yml
@@ -1,0 +1,14 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+      when: molecule_yml.platforms is defined

--- a/roles/acl_tools/molecule/default/molecule.yml
+++ b/roles/acl_tools/molecule/default/molecule.yml
@@ -1,0 +1,37 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: ../../requirements.yml
+    requirements-file: ../../requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: ubuntu-acl-tools
+    image: "geerlingguy/docker-ubuntu2404-ansible:latest"
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+
+  - name: kali-acl-tools
+    image: cisagov/docker-kali-ansible:latest
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+
+provisioner:
+  name: ansible
+  config_file: ${MOLECULE_PROJECT_DIRECTORY}/../../ansible.cfg
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+  env:
+    ANSIBLE_CALLBACK_PLUGINS: "${MOLECULE_SCENARIO_DIRECTORY}/callback_plugins"
+
+verifier:
+  name: ansible

--- a/roles/acl_tools/molecule/default/verify.yml
+++ b/roles/acl_tools/molecule/default/verify.yml
@@ -1,0 +1,196 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Include default variables
+      ansible.builtin.include_vars:
+        file: "../../defaults/main.yml"
+
+    - name: Verify bloodyAD is installed
+      ansible.builtin.command: which bloodyAD
+      register: acl_tools_bloodyad_check
+      changed_when: false
+      failed_when: false
+      environment:
+        PATH: "/root/.local/bin:{{ ansible_facts['env']['PATH'] }}"
+      when: acl_tools_install_bloodyad | default(true)
+
+    - name: Get bloodyAD version
+      ansible.builtin.command: bloodyAD --version
+      register: acl_tools_bloodyad_version
+      changed_when: false
+      failed_when: false
+      environment:
+        PATH: "/root/.local/bin:{{ ansible_facts['env']['PATH'] }}"
+      when:
+        - acl_tools_install_bloodyad | default(true)
+        - acl_tools_bloodyad_check.rc == 0
+
+    - name: Assert bloodyAD is available
+      ansible.builtin.assert:
+        that:
+          - acl_tools_bloodyad_check.rc == 0
+          - acl_tools_bloodyad_check.stdout is defined
+        fail_msg: "bloodyAD is not properly installed"
+        success_msg: "bloodyAD is installed at {{ acl_tools_bloodyad_check.stdout }}"
+      when: acl_tools_install_bloodyad | default(true)
+
+    - name: Verify pywhisker is installed
+      ansible.builtin.command: which pywhisker
+      register: acl_tools_pywhisker_check
+      changed_when: false
+      failed_when: false
+      environment:
+        PATH: "/root/.local/bin:{{ ansible_facts['env']['PATH'] }}"
+      when: acl_tools_install_pywhisker | default(true)
+
+    - name: Get pywhisker version
+      ansible.builtin.command: pywhisker --version
+      register: acl_tools_pywhisker_version
+      changed_when: false
+      failed_when: false
+      environment:
+        PATH: "/root/.local/bin:{{ ansible_facts['env']['PATH'] }}"
+      when:
+        - acl_tools_install_pywhisker | default(true)
+        - acl_tools_pywhisker_check.rc == 0
+
+    - name: Assert pywhisker is available
+      ansible.builtin.assert:
+        that:
+          - acl_tools_pywhisker_check.rc == 0
+          - acl_tools_pywhisker_check.stdout is defined
+        fail_msg: "pywhisker is not properly installed"
+        success_msg: "pywhisker is installed at {{ acl_tools_pywhisker_check.stdout }}"
+      when: acl_tools_install_pywhisker | default(true)
+
+    - name: Test bloodyAD help output
+      ansible.builtin.shell: set -o pipefail && bloodyAD --help 2>&1 | head -5
+      register: acl_tools_bloodyad_test
+      changed_when: false
+      failed_when: false
+      environment:
+        PATH: "/root/.local/bin:{{ ansible_facts['env']['PATH'] }}"
+      args:
+        executable: /bin/bash
+      when:
+        - acl_tools_install_bloodyad | default(true)
+        - acl_tools_bloodyad_check.rc == 0
+
+    - name: Assert bloodyAD is functional
+      ansible.builtin.assert:
+        that:
+          - acl_tools_bloodyad_test.rc != 127
+        fail_msg: "bloodyAD is not functioning (rc={{ acl_tools_bloodyad_test.rc }})"
+        success_msg: "bloodyAD is functional"
+      when:
+        - acl_tools_install_bloodyad | default(true)
+        - acl_tools_bloodyad_check.rc == 0
+
+    - name: Test pywhisker help output
+      ansible.builtin.shell: set -o pipefail && pywhisker --help 2>&1 | head -5
+      register: acl_tools_pywhisker_test
+      changed_when: false
+      failed_when: false
+      environment:
+        PATH: "/root/.local/bin:{{ ansible_facts['env']['PATH'] }}"
+      args:
+        executable: /bin/bash
+      when:
+        - acl_tools_install_pywhisker | default(true)
+        - acl_tools_pywhisker_check.rc == 0
+
+    - name: Assert pywhisker is functional
+      ansible.builtin.assert:
+        that:
+          - acl_tools_pywhisker_test.rc != 127
+        fail_msg: "pywhisker is not functioning (rc={{ acl_tools_pywhisker_test.rc }})"
+        success_msg: "pywhisker is functional"
+      when:
+        - acl_tools_install_pywhisker | default(true)
+        - acl_tools_pywhisker_check.rc == 0
+
+    # Verify impacket regsecrets module is available in the impacket venv
+    # This ensures the source install is correct and __init__.py was created
+    - name: Verify impacket regsecrets module in venv
+      ansible.builtin.command: /opt/impacket/venv/bin/python -c "from impacket.examples import regsecrets; print('OK')"
+      register: acl_tools_regsecrets_check
+      changed_when: false
+      failed_when: false
+      when: acl_tools_install_dacledit | default(true)
+
+    - name: Assert impacket regsecrets module is available
+      ansible.builtin.assert:
+        that:
+          - acl_tools_regsecrets_check.rc == 0
+        fail_msg: "impacket.examples.regsecrets not found in impacket venv"
+        success_msg: "impacket regsecrets module available in venv"
+      when: acl_tools_install_dacledit | default(true)
+
+    # Verify pywhisker --no-deps didn't break impacket (downgrade to 0.12.0)
+    - name: Check impacket version was not downgraded by pywhisker
+      ansible.builtin.command: /opt/impacket/venv/bin/python -c "import importlib.metadata; print(importlib.metadata.version('impacket'))"
+      register: acl_tools_impacket_version_check
+      changed_when: false
+      failed_when: false
+      when: acl_tools_install_dacledit | default(true)
+
+    - name: Assert impacket version is 0.13.0+
+      ansible.builtin.assert:
+        that:
+          - acl_tools_impacket_version_check.rc == 0
+          - acl_tools_impacket_version_check.stdout is version('0.13.0', '>=')
+        fail_msg: >-
+          impacket version {{ acl_tools_impacket_version_check.stdout | default('unknown') }}
+          is too old (need >= 0.13.0). pywhisker may have downgraded it.
+        success_msg: "impacket version {{ acl_tools_impacket_version_check.stdout }} (>= 0.13.0)"
+      when:
+        - acl_tools_install_dacledit | default(true)
+        - acl_tools_impacket_version_check.rc == 0
+
+    - name: Verify rpcclient is installed
+      ansible.builtin.command: which rpcclient
+      environment:
+        PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      register: acl_tools_rpcclient_check
+      changed_when: false
+      failed_when: false
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Assert rpcclient is available
+      ansible.builtin.assert:
+        that:
+          - acl_tools_rpcclient_check.rc == 0
+          - acl_tools_rpcclient_check.stdout is defined
+        fail_msg: "rpcclient is not installed"
+        success_msg: "rpcclient is available at {{ acl_tools_rpcclient_check.stdout }}"
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Display verification summary
+      ansible.builtin.debug:
+        msg:
+          - "=== ACL Tools Verification Complete ==="
+          - >-
+            bloodyAD:
+            {{ acl_tools_bloodyad_check.stdout
+               if acl_tools_bloodyad_check is defined and acl_tools_bloodyad_check.rc == 0
+               else 'Not installed' }}
+          - >-
+            bloodyAD version:
+            {{ acl_tools_bloodyad_version.stdout
+               if acl_tools_bloodyad_version is defined and acl_tools_bloodyad_version.rc == 0
+               else 'N/A' }}
+          - >-
+            pywhisker:
+            {{ acl_tools_pywhisker_check.stdout
+               if acl_tools_pywhisker_check is defined and acl_tools_pywhisker_check.rc == 0
+               else 'Not installed' }}
+          - >-
+            pywhisker version:
+            {{ acl_tools_pywhisker_version.stdout
+               if acl_tools_pywhisker_version is defined and acl_tools_pywhisker_version.rc == 0
+               else 'N/A' }}
+          - "impacket regsecrets: {{ 'OK' if acl_tools_regsecrets_check.rc | default(1) == 0 else 'NOT FOUND' }}"
+          - "impacket version: {{ acl_tools_impacket_version_check.stdout | default('N/A') }}"
+          - "===================================================="

--- a/roles/acl_tools/tasks/impacket_source.yml
+++ b/roles/acl_tools/tasks/impacket_source.yml
@@ -1,0 +1,172 @@
+---
+# Install Impacket from GitHub source
+# Pulls the latest examples (including regsecrets) for relay and delegation tooling
+# Reference: https://github.com/fortra/impacket
+
+- name: Install git for cloning impacket
+  ansible.builtin.apt:
+    name: git
+    state: present
+  become: true
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Remove conflicting apt impacket packages (Ubuntu only - Kali netexec depends on them)
+  ansible.builtin.apt:
+    name:
+      - python3-impacket
+      - impacket-scripts
+    state: absent
+    purge: true
+  become: true
+  failed_when: false
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+
+- name: Check if impacket is installed from source
+  ansible.builtin.stat:
+    path: "{{ acl_tools_impacket_install_dir }}/impacket/__init__.py"
+  register: acl_tools_impacket_source_check
+
+- name: Check if impacket repo already exists
+  ansible.builtin.stat:
+    path: "{{ acl_tools_impacket_install_dir }}/.git"
+  register: acl_tools_impacket_git_check
+
+- name: Clone impacket repository from GitHub (initial clone)
+  ansible.builtin.git:
+    repo: "{{ acl_tools_impacket_repo }}"
+    dest: "{{ acl_tools_impacket_install_dir }}"
+    version: "{{ acl_tools_impacket_version }}"
+  become: true
+  register: acl_tools_impacket_clone
+  when: not acl_tools_impacket_git_check.stat.exists
+
+- name: Set impacket venv path
+  ansible.builtin.set_fact:
+    acl_tools_impacket_venv: "{{ acl_tools_impacket_install_dir }}/venv"
+
+- name: Check if impacket venv exists
+  ansible.builtin.stat:
+    path: "{{ acl_tools_impacket_venv }}/bin/python"
+  register: acl_tools_impacket_venv_check
+
+- name: Check if we need to install or reinstall impacket
+  ansible.builtin.set_fact:
+    acl_tools_needs_impacket_install: >-
+      {{
+        (not acl_tools_impacket_venv_check.stat.exists)
+        or (acl_tools_impacket_clone.changed | default(false))
+      }}
+    acl_tools_force_impacket_reinstall: >-
+      {{
+        (acl_tools_impacket_clone.changed | default(false))
+      }}
+
+- name: Create impacket virtual environment
+  ansible.builtin.command:
+    cmd: "python3 -m venv {{ acl_tools_impacket_venv }}"
+  become: true
+  args:
+    creates: "{{ acl_tools_impacket_venv }}/bin/python"
+  when: acl_tools_needs_impacket_install | bool
+
+- name: Install impacket from source
+  ansible.builtin.pip:
+    name: "{{ acl_tools_impacket_install_dir }}"
+    virtualenv: "{{ acl_tools_impacket_venv }}"
+    editable: true
+    # Use forcereinstall when we removed the wrong installation or git repo changed
+    # Otherwise use present for idempotent behavior (won't reinstall if already installed)
+    state: "{{ 'forcereinstall' if acl_tools_force_impacket_reinstall else 'present' }}"
+    # Add --ignore-installed when force reinstalling to handle cached packages in the venv.
+    extra_args: "{{ '--ignore-installed' if acl_tools_force_impacket_reinstall else '' }}"
+  become: true
+  register: acl_tools_impacket_install
+  when: acl_tools_needs_impacket_install | bool
+
+- name: Check if impacket is correctly installed in venv
+  ansible.builtin.command: "{{ acl_tools_impacket_venv }}/bin/python -c \"import impacket; print(impacket.__file__)\""
+  register: acl_tools_impacket_import_check
+  changed_when: false
+  failed_when: false
+
+- name: Make impacket example scripts executable
+  ansible.builtin.shell: |
+    chmod +x {{ acl_tools_impacket_install_dir }}/examples/*.py
+  args:
+    executable: /bin/bash
+  become: true
+  changed_when: false
+
+- name: Check if \_\_init\_\_.py exists in impacket/examples
+  ansible.builtin.stat:
+    path: "{{ acl_tools_impacket_install_dir }}/impacket/examples/__init__.py"
+  register: acl_tools_impacket_init_check
+
+- name: Create \_\_init\_\_.py in impacket/examples to make it a proper Python package
+  ansible.builtin.copy:
+    content: "# Auto-generated __init__.py to make impacket.examples importable\n# Required for NetExec SMB functionality (regsecrets module)\n"
+    dest: "{{ acl_tools_impacket_install_dir }}/impacket/examples/__init__.py"
+    mode: '0644'
+  become: true
+  when: not acl_tools_impacket_init_check.stat.exists
+
+- name: Check system impacket version (Kali)
+  ansible.builtin.command: python3 -c "import importlib.metadata; print(importlib.metadata.version('impacket'))"
+  register: acl_tools_system_impacket_version
+  changed_when: false
+  failed_when: false
+  when:
+    - ansible_facts['distribution'] == 'Kali'
+
+- name: Install source impacket into system Python (Kali apt netexec needs it system-wide)
+  ansible.builtin.pip:
+    name: "{{ acl_tools_impacket_install_dir }}"
+    executable: pip3
+    editable: true
+    state: forcereinstall
+    extra_args: "--break-system-packages --ignore-installed"
+  become: true
+  when:
+    - ansible_facts['distribution'] == 'Kali'
+    - (acl_tools_system_impacket_version.stdout | default('0.0.0', true)) is version('0.13.0', '<')
+      or acl_tools_impacket_clone.changed | default(false)
+
+- name: Create symlinks for impacket scripts (impacket-* style for Kali compatibility)
+  ansible.builtin.shell: |
+    for script in {{ acl_tools_impacket_install_dir }}/examples/*.py; do
+      script_name=$(basename "$script" .py)
+      # Create wrapper scripts that use the impacket venv Python
+      printf '%s\n' '#!/bin/bash' \
+        "exec {{ acl_tools_impacket_venv }}/bin/python \"$script\" \"\$@\"" \
+        > "/usr/local/bin/impacket-$script_name"
+      chmod +x "/usr/local/bin/impacket-$script_name"
+
+      printf '%s\n' '#!/bin/bash' \
+        "exec {{ acl_tools_impacket_venv }}/bin/python \"$script\" \"\$@\"" \
+        > "/usr/local/bin/${script_name}.py"
+      chmod +x "/usr/local/bin/${script_name}.py"
+    done
+  args:
+    executable: /bin/bash
+  become: true
+  changed_when: false
+
+- name: Verify impacket regsecrets module is available
+  ansible.builtin.command: "{{ acl_tools_impacket_venv }}/bin/python -c \"from impacket.examples import regsecrets; print('regsecrets module OK')\""
+  register: acl_tools_regsecrets_check
+  changed_when: false
+  failed_when: false
+
+- name: Report impacket installation status
+  ansible.builtin.debug:
+    msg: |
+      Impacket installation from source: {{
+        'SUCCESS' if acl_tools_impacket_install.changed | default(false)
+                  or not acl_tools_impacket_install.failed | default(false)
+        else 'FAILED'
+      }}
+      Impacket version: {{ acl_tools_impacket_version }}
+      regsecrets module: {{ 'AVAILABLE' if acl_tools_regsecrets_check.rc == 0 else 'NOT FOUND' }}
+      Install directory: {{ acl_tools_impacket_install_dir }}

--- a/roles/acl_tools/tasks/linux.yml
+++ b/roles/acl_tools/tasks/linux.yml
@@ -1,0 +1,217 @@
+---
+- name: Set DEBIAN_FRONTEND to noninteractive
+  ansible.builtin.lineinfile:
+    path: /etc/environment
+    line: 'DEBIAN_FRONTEND=noninteractive'
+    create: true
+    mode: '0644'
+  become: true
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+  become: true
+  when:
+    - acl_tools_update_cache
+    - ansible_facts['os_family'] == 'Debian'
+
+- name: Install Ubuntu-compatible dependencies
+  ansible.builtin.apt:
+    name: "{{ acl_tools_ubuntu_packages }}"
+    state: present
+  become: true
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Check rpcclient availability
+  ansible.builtin.command: command -v rpcclient
+  environment:
+    PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  register: acl_tools_rpcclient_check
+  changed_when: false
+  failed_when: false
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Install smbclient when rpcclient is missing
+  ansible.builtin.apt:
+    name: smbclient
+    state: present
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - acl_tools_rpcclient_check.rc != 0
+
+- name: Recheck rpcclient availability after smbclient install
+  ansible.builtin.command: command -v rpcclient
+  environment:
+    PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  register: acl_tools_rpcclient_recheck
+  changed_when: false
+  failed_when: false
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - acl_tools_rpcclient_check.rc != 0
+
+- name: Check if samba-common-bin package is available
+  ansible.builtin.command: apt-cache show samba-common-bin
+  register: acl_tools_samba_common_bin_available
+  changed_when: false
+  failed_when: false
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - acl_tools_rpcclient_check.rc != 0
+    - acl_tools_rpcclient_recheck.rc != 0
+
+- name: Install samba-common-bin when rpcclient is still missing
+  ansible.builtin.apt:
+    name: samba-common-bin
+    state: present
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - acl_tools_rpcclient_check.rc != 0
+    - acl_tools_rpcclient_recheck.rc != 0
+    - acl_tools_samba_common_bin_available.rc == 0
+
+- name: Install Impacket from source for dacledit
+  ansible.builtin.include_tasks: impacket_source.yml
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - acl_tools_install_dacledit
+    - acl_tools_impacket_from_source
+
+- name: Install bloodyAD via apt (Kali)
+  ansible.builtin.apt:
+    name: "{{ acl_tools_bloodyad_apt_package }}"
+    state: present
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] == 'Kali'
+    - acl_tools_install_bloodyad
+
+# Kali's apt package ships the binary as lowercase `bloodyad`; upstream (pip)
+# ships it as `bloodyAD`. Normalize with a symlink so callers, verify tests,
+# and docs can rely on the mixed-case name regardless of install source.
+- name: Ensure bloodyAD symlink for Kali apt install
+  ansible.builtin.file:
+    src: /usr/bin/bloodyad
+    dest: /usr/local/bin/bloodyAD
+    state: link
+    force: true
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] == 'Kali'
+    - acl_tools_install_bloodyad
+
+- name: Check if bloodyAD is already installed
+  ansible.builtin.command: pip3 show bloodyAD
+  register: acl_tools_bloodyad_check
+  changed_when: false
+  failed_when: false
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+    - acl_tools_install_bloodyad
+
+- name: Install bloodyAD via pip
+  ansible.builtin.pip:
+    name: "{{ acl_tools_bloodyad_package }}"
+    executable: pip3
+    # Use --ignore-installed to handle system packages (e.g., cryptography on Kali/Ubuntu)
+    # that can't be uninstalled because they were installed by apt (no RECORD file)
+    extra_args: "{{ ('--break-system-packages ' if (acl_tools_pip_break_system_packages | default(false)) else '') ~ '--ignore-installed' }}"
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+    - acl_tools_install_bloodyad
+    - acl_tools_bloodyad_check.rc != 0
+
+# pywhisker's PFX export uses OpenSSL.crypto.PKCS12, which later pyOpenSSL
+# releases removed; the 24.x line still ships it, hence pyOpenSSL<25. Keep this
+# confined to pywhisker's own venv: the system pyOpenSSL must stay >=24 for
+# impacket-ldap tooling (nxc, secretsdump), because a system-wide pyOpenSSL<24
+# references cryptography's _lib.GEN_EMAIL (removed in cryptography>=42) and
+# crashes every `import OpenSSL`. The pip module builds the venv itself via
+# `python3 -m venv`, so no separate creation task is needed.
+- name: Install pywhisker in an isolated virtualenv
+  ansible.builtin.pip:
+    name:
+      - "{{ acl_tools_pywhisker_package }}"
+      - "{{ acl_tools_pyopenssl_package }}"
+    virtualenv: "{{ acl_tools_pywhisker_install_dir }}/venv"
+    virtualenv_command: python3 -m venv
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - acl_tools_install_pywhisker
+
+- name: Create wrapper script for pywhisker
+  ansible.builtin.copy:
+    content: |
+      #!/bin/bash
+      exec {{ acl_tools_pywhisker_install_dir }}/venv/bin/pywhisker "$@"
+    dest: /usr/local/bin/pywhisker
+    mode: '0755'
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - acl_tools_install_pywhisker
+
+- name: Clone targetedKerberoast from GitHub
+  ansible.builtin.git:
+    repo: "{{ acl_tools_targetedkerberoast_repo }}"
+    dest: "{{ acl_tools_targetedkerberoast_install_dir }}"
+    version: "{{ acl_tools_targetedkerberoast_version }}"
+    force: true
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - acl_tools_install_targetedkerberoast
+
+- name: Create virtual environment for targetedKerberoast
+  ansible.builtin.command:
+    cmd: python3 -m venv {{ acl_tools_targetedkerberoast_install_dir }}/venv
+  become: true
+  args:
+    creates: "{{ acl_tools_targetedkerberoast_install_dir }}/venv"
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - acl_tools_install_targetedkerberoast
+
+- name: Install targetedKerberoast dependencies in venv
+  ansible.builtin.pip:
+    requirements: "{{ acl_tools_targetedkerberoast_install_dir }}/requirements.txt"
+    virtualenv: "{{ acl_tools_targetedkerberoast_install_dir }}/venv"
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - acl_tools_install_targetedkerberoast
+
+- name: Create wrapper script for targetedKerberoast
+  ansible.builtin.copy:
+    content: |
+      #!/bin/bash
+      exec {{ acl_tools_targetedkerberoast_install_dir }}/venv/bin/python \
+           {{ acl_tools_targetedkerberoast_install_dir }}/targetedKerberoast.py "$@"
+    dest: /usr/local/bin/targetedKerberoast
+    mode: '0755'
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - acl_tools_install_targetedkerberoast
+
+- name: Create .py symlink for targetedKerberoast
+  ansible.builtin.file:
+    src: /usr/local/bin/targetedKerberoast
+    dest: /usr/local/bin/targetedKerberoast.py
+    state: link
+    force: true
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - acl_tools_install_targetedkerberoast

--- a/roles/acl_tools/tasks/main.yml
+++ b/roles/acl_tools/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Include Linux tasks
+  ansible.builtin.include_tasks: linux.yml
+  when: ansible_os_family != 'Windows'


### PR DESCRIPTION
**Key Changes:**

- Introduced a new `acl_tools` Ansible role that installs and configures Active Directory ACL exploitation tools across Ubuntu, Debian, and Kali Linux
- Implements isolated virtual environments for pywhisker and targetedKerberoast to avoid dependency conflicts, particularly around pyOpenSSL version pinning
- Installs impacket from source (v0.13.0) with full `impacket-*` symlink generation and Kali-specific compatibility handling
- Registered `acl_tools` in CI matrix and documentation alongside existing roles

**Added:**

- `acl_tools` role - New role installing bloodyAD, pywhisker, dacledit (via impacket), and targetedKerberoast with per-tool virtual environments and wrapper scripts for consistent binary naming across distributions (`roles/acl_tools/`)
- Impacket source installation task - Clones fortra/impacket at tag `impacket_0_13_0`, creates a dedicated venv, generates `impacket-*` and `.py`-suffixed symlinks in `/usr/local/bin`, and creates `impacket/examples/__init__.py` to ensure the `regsecrets` module is importable (`roles/acl_tools/tasks/impacket_source.yml`)
- Molecule test suite - Full converge, verify, create, destroy, and task-profiling callback plugin for testing against `geerlingguy/docker-ubuntu2404-ansible` and `cisagov/docker-kali-ansible` containers; verify playbook asserts binary presence, impacket version >= 0.13.0, and regsecrets module availability (`roles/acl_tools/molecule/default/`)
- Role defaults and metadata - Configurable variables for each tool's install path, package name, version, and toggle flags; Galaxy metadata with `security`, `pentesting`, `activedirectory`, and `privesc` tags (`roles/acl_tools/defaults/main.yml`, `roles/acl_tools/meta/main.yml`)
- Role documentation - Auto-generated README covering all default variables, task summaries per task file, example playbook, and supported platforms (`roles/acl_tools/README.md`)

**Changed:**

- CI test matrix - Added `acl_tools` role entry to the full test matrix in `.github/workflows/molecule.yaml` so it is included in all-roles test runs
- README role listing - Added `acl_tools` to the Mermaid dependency graph and the role reference table with a description linking to its README (`README.md`)