### PR TITLE
feat: add coercion_tools ansible role for network poisoning and relay attacks

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -116,7 +116,7 @@ jobs:
         run: |
           if [[ "${{ steps.check-event.outputs.test_all }}" == "true" ]]; then
             # Test all roles and playbooks
-            MATRIX_JSON='[{"name":"Role Test - acl_tools","path":"roles/acl_tools"},{"name":"Role Test - attack_box","path":"roles/attack_box"},{"name":"Role Test - mythic","path":"roles/mythic"},{"name":"Role Test - recon_toolkit","path":"roles/recon_toolkit"},{"name":"Role Test - sliver","path":"roles/sliver"},{"name":"Role Test - ttpforge","path":"roles/ttpforge"},{"name":"Playbook Test - atomic-red-team","path":"playbooks/atomic-red-team"},{"name":"Playbook Test - attack_box","path":"playbooks/attack_box"},{"name":"Playbook Test - recon_toolkit","path":"playbooks/recon_toolkit"},{"name":"Playbook Test - sliver","path":"playbooks/sliver"},{"name":"Playbook Test - ttpforge","path":"playbooks/ttpforge"}]'
+            MATRIX_JSON='[{"name":"Role Test - attack_box","path":"roles/attack_box"},{"name":"Role Test - coercion_tools","path":"roles/coercion_tools"},{"name":"Role Test - mythic","path":"roles/mythic"},{"name":"Role Test - recon_toolkit","path":"roles/recon_toolkit"},{"name":"Role Test - sliver","path":"roles/sliver"},{"name":"Role Test - ttpforge","path":"roles/ttpforge"},{"name":"Playbook Test - atomic-red-team","path":"playbooks/atomic-red-team"},{"name":"Playbook Test - attack_box","path":"playbooks/attack_box"},{"name":"Playbook Test - recon_toolkit","path":"playbooks/recon_toolkit"},{"name":"Playbook Test - sliver","path":"playbooks/sliver"},{"name":"Playbook Test - ttpforge","path":"playbooks/ttpforge"}]'
           else
             # Test only changed roles and playbooks
             ROLES="${{ steps.filter.outputs.roles }}"

--- a/README.md
+++ b/README.md
@@ -14,12 +14,11 @@ that I employ regularly.
 graph TD
     Collection[Ansible Collection]
     Collection --> Roles[⚙️ Roles]
-    Roles --> R0[acl_tools 🧪]
-    Roles --> R1[attack_box 🧪]
-    Roles --> R2[mythic 🧪]
-    Roles --> R3[recon_toolkit 🧪]
-    Roles --> R4[sliver 🧪]
-    Roles --> R5[ttpforge 🧪]
+    Roles --> R0[attack_box 🧪]
+    Roles --> R1[coercion_tools 🧪]
+    Roles --> R2[recon_toolkit 🧪]
+    Roles --> R3[sliver 🧪]
+    Roles --> R4[ttpforge 🧪]
     Collection --> Playbooks[📚 Playbooks]
     Playbooks --> PB0[atomic-red-team 🧪]
     Playbooks --> PB1[attack_box 🧪]
@@ -54,9 +53,8 @@ ansible-galaxy collection build --force && \
 
 | Role | Description |
 | ---- | ----------- |
-| [`acl_tools`](roles/acl_tools/README.md) | Install and configure Active Directory ACL exploitation tools |
 | [`attack_box`](roles/attack_box/README.md) | Creates an attack box for penetration testing and red teaming |
-| [`mythic`](roles/mythic/README.md) | Install and configure the Mythic C2 framework |
+| [`coercion_tools`](roles/coercion_tools/README.md) | Install and configure network poisoning and relay attack tools |
 | [`recon_toolkit`](roles/recon_toolkit/README.md) | Install reconnaissance tools for subdomain enumeration, HTTP discovery, web crawling, vulnerability scanning, and parameter analysis |
 | [`sliver`](roles/sliver/README.md) | Install sliver c2 |
 | [`ttpforge`](roles/ttpforge/README.md) | TTPForge is a Cybersecurity Framework for developing, automating, and executing attacker Tactics, Techniques, and Procedures (TTPs) |

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ that I employ regularly.
 graph TD
     Collection[Ansible Collection]
     Collection --> Roles[⚙️ Roles]
-    Roles --> R0[attack_box 🧪]
-    Roles --> R1[coercion_tools 🧪]
-    Roles --> R2[recon_toolkit 🧪]
-    Roles --> R3[sliver 🧪]
-    Roles --> R4[ttpforge 🧪]
+    Roles --> R0[acl_tools 🧪]
+    Roles --> R1[attack_box 🧪]
+    Roles --> R2[coercion_tools 🧪]
+    Roles --> R3[mythic 🧪]
+    Roles --> R4[recon_toolkit 🧪]
+    Roles --> R5[sliver 🧪]
+    Roles --> R6[ttpforge 🧪]
     Collection --> Playbooks[📚 Playbooks]
     Playbooks --> PB0[atomic-red-team 🧪]
     Playbooks --> PB1[attack_box 🧪]
@@ -53,8 +55,10 @@ ansible-galaxy collection build --force && \
 
 | Role | Description |
 | ---- | ----------- |
+| [`acl_tools`](roles/acl_tools/README.md) | Install and configure Active Directory ACL exploitation tools |
 | [`attack_box`](roles/attack_box/README.md) | Creates an attack box for penetration testing and red teaming |
 | [`coercion_tools`](roles/coercion_tools/README.md) | Install and configure network poisoning and relay attack tools |
+| [`mythic`](roles/mythic/README.md) | Install and configure the Mythic C2 framework |
 | [`recon_toolkit`](roles/recon_toolkit/README.md) | Install reconnaissance tools for subdomain enumeration, HTTP discovery, web crawling, vulnerability scanning, and parameter analysis |
 | [`sliver`](roles/sliver/README.md) | Install sliver c2 |
 | [`ttpforge`](roles/ttpforge/README.md) | TTPForge is a Cybersecurity Framework for developing, automating, and executing attacker Tactics, Techniques, and Procedures (TTPs) |

--- a/roles/coercion_tools/README.md
+++ b/roles/coercion_tools/README.md
@@ -1,0 +1,171 @@
+<!-- DOCSIBLE START -->
+# coercion_tools
+
+## Description
+
+Install and configure network poisoning and relay attack tools
+
+## Requirements
+
+- Ansible >= 2.14
+
+## Role Variables
+
+### Default Variables (main.yml)
+
+| Variable | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `coercion_tools_kali_packages` | list | <code>&#91;&#93;</code> | No description |
+| `coercion_tools_kali_packages.0` | str | <code>responder</code> | No description |
+| `coercion_tools_kali_packages.1` | str | <code>samba-common-bin</code> | No description |
+| `coercion_tools_kali_packages.2` | str | <code>python3-dev</code> | No description |
+| `coercion_tools_kali_packages.3` | str | <code>python3-venv</code> | No description |
+| `coercion_tools_kali_packages.4` | str | <code>build-essential</code> | No description |
+| `coercion_tools_kali_packages.5` | str | <code>git</code> | No description |
+| `coercion_tools_ubuntu_packages` | list | <code>&#91;&#93;</code> | No description |
+| `coercion_tools_ubuntu_packages.0` | str | <code>git</code> | No description |
+| `coercion_tools_ubuntu_packages.1` | str | <code>python3</code> | No description |
+| `coercion_tools_ubuntu_packages.2` | str | <code>python3-pip</code> | No description |
+| `coercion_tools_ubuntu_packages.3` | str | <code>python3-dev</code> | No description |
+| `coercion_tools_ubuntu_packages.4` | str | <code>python3-venv</code> | No description |
+| `coercion_tools_ubuntu_packages.5` | str | <code>build-essential</code> | No description |
+| `coercion_tools_ubuntu_packages.6` | str | <code>linux-libc-dev</code> | No description |
+| `coercion_tools_ubuntu_packages.7` | str | <code>samba-common-bin</code> | No description |
+| `coercion_tools_install_responder` | bool | <code>True</code> | No description |
+| `coercion_tools_responder_repo` | str | <code>https://github.com/lgandx/Responder.git</code> | No description |
+| `coercion_tools_responder_install_dir` | str | <code>/opt/Responder</code> | No description |
+| `coercion_tools_responder_version` | str | <code>v3.1.4.0</code> | No description |
+| `coercion_tools_install_mitm6` | bool | <code>True</code> | No description |
+| `coercion_tools_mitm6_package` | str | <code>mitm6</code> | No description |
+| `coercion_tools_mitm6_install_dir` | str | <code>/opt/mitm6</code> | No description |
+| `coercion_tools_install_coercer` | bool | <code>True</code> | No description |
+| `coercion_tools_coercer_package` | str | <code>coercer</code> | No description |
+| `coercion_tools_install_petitpotam` | bool | <code>True</code> | No description |
+| `coercion_tools_petitpotam_repo` | str | <code>https://github.com/ly4k/PetitPotam.git</code> | No description |
+| `coercion_tools_petitpotam_install_dir` | str | <code>/opt/PetitPotam</code> | No description |
+| `coercion_tools_petitpotam_version` | str | <code>main</code> | No description |
+| `coercion_tools_install_krbrelayx` | bool | <code>True</code> | No description |
+| `coercion_tools_krbrelayx_repo` | str | <code>https://github.com/dirkjanm/krbrelayx.git</code> | No description |
+| `coercion_tools_krbrelayx_install_dir` | str | <code>/opt/krbrelayx</code> | No description |
+| `coercion_tools_krbrelayx_version` | str | <code>master</code> | No description |
+| `coercion_tools_install_ntlmrelayx` | bool | <code>True</code> | No description |
+| `coercion_tools_impacket_from_source` | bool | <code>True</code> | No description |
+| `coercion_tools_impacket_repo` | str | <code>https://github.com/fortra/impacket.git</code> | No description |
+| `coercion_tools_impacket_version` | str | <code>impacket_0_13_0</code> | No description |
+| `coercion_tools_impacket_install_dir` | str | <code>/opt/impacket</code> | No description |
+| `coercion_tools_install_dfscoerce` | bool | <code>True</code> | No description |
+| `coercion_tools_dfscoerce_repo` | str | <code>https://github.com/Wh04m1001/DFSCoerce.git</code> | No description |
+| `coercion_tools_dfscoerce_install_dir` | str | <code>/opt/DFSCoerce</code> | No description |
+| `coercion_tools_dfscoerce_version` | str | <code>main</code> | No description |
+| `coercion_tools_update_cache` | bool | <code>True</code> | No description |
+| `coercion_tools_pip_break_system_packages` | bool | <code>False</code> | No description |
+| `coercion_tools_binaries` | dict | <code>{}</code> | No description |
+| `coercion_tools_binaries.responder` | str | <code>/usr/local/bin/responder</code> | No description |
+| `coercion_tools_binaries.mitm6` | str | <code>/usr/local/bin/mitm6</code> | No description |
+| `coercion_tools_binaries.coercer` | str | <code>/usr/local/bin/coercer</code> | No description |
+| `coercion_tools_binaries.petitpotam` | str | <code>/usr/local/bin/petitpotam</code> | No description |
+| `coercion_tools_binaries.krbrelayx` | str | <code>/usr/local/bin/krbrelayx</code> | No description |
+| `coercion_tools_binaries.addspn` | str | <code>/usr/local/bin/addspn</code> | No description |
+| `coercion_tools_binaries.dnstool` | str | <code>/usr/local/bin/dnstool</code> | No description |
+| `coercion_tools_binaries.ntlmrelayx` | str | <code>/usr/local/bin/impacket-ntlmrelayx</code> | No description |
+| `coercion_tools_binaries.dfscoerce` | str | <code>/usr/local/bin/dfscoerce</code> | No description |
+
+## Tasks
+
+### impacket_source.yml
+
+
+- **Install git for cloning impacket** (ansible.builtin.apt) - Conditional
+- **Remove conflicting apt impacket packages (Ubuntu only - Kali netexec depends on them)** (ansible.builtin.apt) - Conditional
+- **Check if impacket is installed from source** (ansible.builtin.stat)
+- **Check if impacket repo already exists** (ansible.builtin.stat)
+- **Clone impacket repository from GitHub (initial clone)** (ansible.builtin.git) - Conditional
+- **Set impacket venv path** (ansible.builtin.set_fact)
+- **Check if impacket venv exists** (ansible.builtin.stat)
+- **Check if we need to install or reinstall impacket** (ansible.builtin.set_fact)
+- **Create impacket virtual environment** (ansible.builtin.command) - Conditional
+- **Install impacket from source** (ansible.builtin.pip) - Conditional
+- **Upgrade pycryptodome in impacket venv (CVE fix - GHSA-j225-cvw7-qrx7)** (ansible.builtin.pip) - Conditional
+- **Check if impacket is correctly installed in venv** (ansible.builtin.command)
+- **Make impacket example scripts executable** (ansible.builtin.shell)
+- **Check if \_\_init\_\_.py exists in impacket/examples** (ansible.builtin.stat)
+- **Create \_\_init\_\_.py in impacket/examples to make it a proper Python package** (ansible.builtin.copy) - Conditional
+- **Check system impacket version (Kali)** (ansible.builtin.command) - Conditional
+- **Install source impacket into system Python (Kali apt netexec needs it system-wide)** (ansible.builtin.pip) - Conditional
+- **Enumerate impacket example scripts** (ansible.builtin.find)
+- **Fail loudly if impacket examples were not found** (ansible.builtin.assert)
+- **Install venv-aware bash wrappers for impacket example scripts (no .py suffix)** (ansible.builtin.copy)
+- **Install venv-aware bash wrappers for impacket example scripts (.py suffix)** (ansible.builtin.copy)
+- **Verify impacket regsecrets module is available** (ansible.builtin.command)
+- **Report impacket installation status** (ansible.builtin.debug)
+
+### linux.yml
+
+
+- **Wait for apt locks to be released** (ansible.builtin.shell) - Conditional
+- **Set DEBIAN_FRONTEND to noninteractive** (ansible.builtin.lineinfile) - Conditional
+- **Update apt cache** (ansible.builtin.apt) - Conditional
+- **Remove conflicting python3-responder package on Kali** (ansible.builtin.apt) - Conditional
+- **Install Kali-specific poisoning tools (includes responder from apt)** (ansible.builtin.apt) - Conditional
+- **Install Ubuntu-compatible dependencies** (ansible.builtin.apt) - Conditional
+- **Check if Coercer is already installed (non-Kali)** (ansible.builtin.command) - Conditional
+- **Install Coercer via pip (non-Kali)** (ansible.builtin.pip) - Conditional
+- **Install Impacket from source for ntlmrelayx** (ansible.builtin.include_tasks) - Conditional
+- **Check for ntlmrelayx.py wrapper** (ansible.builtin.stat) - Conditional
+- **Create ntlmrelayx wrapper script** (ansible.builtin.copy) - Conditional
+- **Clone Responder from GitHub** (ansible.builtin.git) - Conditional
+- **Check if Responder dependencies are installed** (ansible.builtin.command) - Conditional
+- **Install Responder dependencies (non-Kali)** (ansible.builtin.pip) - Conditional
+- **Make Responder.py executable** (ansible.builtin.file) - Conditional
+- **Create symlink for Responder** (ansible.builtin.file) - Conditional
+- **Install mitm6 via venv (non-Kali)** (ansible.builtin.include_tasks) - Conditional
+- **Install mitm6 via apt (Kali)** (ansible.builtin.apt) - Conditional
+- **Install Coercer via apt (Kali)** (ansible.builtin.apt) - Conditional
+- **Clone PetitPotam from GitHub (ly4k's improved version)** (ansible.builtin.git) - Conditional
+- **Make petitpotam.py executable** (ansible.builtin.file) - Conditional
+- **Create symlink for PetitPotam (Kali)** (ansible.builtin.file) - Conditional
+- **Stat existing PetitPotam launcher (non-Kali)** (ansible.builtin.stat) - Conditional
+- **Remove legacy PetitPotam symlink so the wrapper can replace it** (ansible.builtin.file) - Conditional
+- **Install venv-aware bash wrapper for PetitPotam (non-Kali)** (ansible.builtin.copy) - Conditional
+- **Clone krbrelayx from GitHub** (ansible.builtin.git) - Conditional
+- **Configure git to ignore filemode changes in krbrelayx repo** (ansible.builtin.command) - Conditional
+- **Create virtual environment for krbrelayx** (ansible.builtin.command) - Conditional
+- **Install krbrelayx dependencies in venv** (ansible.builtin.pip) - Conditional
+- **Create wrapper scripts for krbrelayx tools** (ansible.builtin.copy) - Conditional
+- **Clone dfscoerce from GitHub** (ansible.builtin.git) - Conditional
+- **Make dfscoerce.py executable** (ansible.builtin.file) - Conditional
+- **Create symlink for dfscoerce** (ansible.builtin.file) - Conditional
+
+### main.yml
+
+
+- **Include Linux tasks** (ansible.builtin.include_tasks) - Conditional
+
+### mitm6_venv.yml
+
+
+- **Install mitm6 in an isolated virtualenv** (ansible.builtin.pip)
+- **Create wrapper script for mitm6** (ansible.builtin.copy)
+- **Symlink mitm6 into /usr/bin** (ansible.builtin.file)
+
+## Example Playbook
+
+```yaml
+- hosts: servers
+  roles:
+    - coercion_tools
+```
+
+## Author Information
+
+- **Author**: Jayson Grace
+- **Company**: techvomit
+- **License**: MIT
+
+## Platforms
+
+
+- Ubuntu: all
+- Debian: all
+- Kali: all
+<!-- DOCSIBLE END -->

--- a/roles/coercion_tools/defaults/main.yml
+++ b/roles/coercion_tools/defaults/main.yml
@@ -27,9 +27,9 @@ coercion_tools_responder_install_dir: "/opt/Responder"
 # Pin to latest stable release for reproducibility
 coercion_tools_responder_version: "v3.1.4.0"
 
-# Responder lifecycle (challenge pinning, NetNTLMv1 downgrade, listener
-# start/stop) is owned by the ares worker via `start_responder` and the
-# auto-responder path in coercer/petitpotam/dfscoerce, not by ansible.
+# This role installs Responder only. Runtime lifecycle (challenge pinning,
+# NetNTLMv1 downgrade, listener start/stop) is expected to be driven by the
+# consuming playbook or operator tooling, not by this role.
 
 # mitm6 configuration (DHCPv6 poisoning)
 coercion_tools_install_mitm6: true

--- a/roles/coercion_tools/defaults/main.yml
+++ b/roles/coercion_tools/defaults/main.yml
@@ -1,0 +1,87 @@
+---
+# Poisoning and relay tool packages (Kali-specific, available in apt)
+coercion_tools_kali_packages:
+  - responder
+  - samba-common-bin
+  - python3-dev
+  - python3-venv
+  - build-essential
+  - git
+
+# Poisoning and relay tool packages (Ubuntu-compatible)
+coercion_tools_ubuntu_packages:
+  - git
+  - python3
+  - python3-pip
+  - python3-dev
+  - python3-venv
+  - build-essential
+  - linux-libc-dev
+  - samba-common-bin
+
+# Responder configuration (git clone for Ubuntu, apt for Kali)
+# Reference: https://github.com/lgandx/Responder/releases
+coercion_tools_install_responder: true
+coercion_tools_responder_repo: "https://github.com/lgandx/Responder.git"
+coercion_tools_responder_install_dir: "/opt/Responder"
+# Pin to latest stable release for reproducibility
+coercion_tools_responder_version: "v3.1.4.0"
+
+# Responder lifecycle (challenge pinning, NetNTLMv1 downgrade, listener
+# start/stop) is owned by the ares worker via `start_responder` and the
+# auto-responder path in coercer/petitpotam/dfscoerce, not by ansible.
+
+# mitm6 configuration (DHCPv6 poisoning)
+coercion_tools_install_mitm6: true
+coercion_tools_mitm6_package: "mitm6"
+coercion_tools_mitm6_install_dir: "/opt/mitm6"
+
+# Coercer configuration (authentication coercion framework)
+coercion_tools_install_coercer: true
+coercion_tools_coercer_package: "coercer"
+
+# PetitPotam configuration (MS-EFSRPC coercion)
+# Note: ly4k/PetitPotam has no release tags, using main branch
+# Reference: https://github.com/ly4k/PetitPotam
+coercion_tools_install_petitpotam: true
+coercion_tools_petitpotam_repo: "https://github.com/ly4k/PetitPotam.git"
+coercion_tools_petitpotam_install_dir: "/opt/PetitPotam"
+coercion_tools_petitpotam_version: "main"
+
+# krbrelayx configuration (Kerberos relay attacks)
+# Reference: https://github.com/dirkjanm/krbrelayx
+# Note: Repository has no release tags, using master branch
+coercion_tools_install_krbrelayx: true
+coercion_tools_krbrelayx_repo: "https://github.com/dirkjanm/krbrelayx.git"
+coercion_tools_krbrelayx_install_dir: "/opt/krbrelayx"
+coercion_tools_krbrelayx_version: "master"
+
+# ntlmrelayx configuration (Impacket relay attacks)
+coercion_tools_install_ntlmrelayx: true
+coercion_tools_impacket_from_source: true
+coercion_tools_impacket_repo: "https://github.com/fortra/impacket.git"
+coercion_tools_impacket_version: "impacket_0_13_0"
+coercion_tools_impacket_install_dir: "/opt/impacket"
+
+# dfscoerce configuration (DFS coercion)
+# Reference: https://github.com/Wh04m1001/DFSCoerce
+coercion_tools_install_dfscoerce: true
+coercion_tools_dfscoerce_repo: "https://github.com/Wh04m1001/DFSCoerce.git"
+coercion_tools_dfscoerce_install_dir: "/opt/DFSCoerce"
+coercion_tools_dfscoerce_version: "main"
+
+coercion_tools_update_cache: true
+
+coercion_tools_pip_break_system_packages: false
+
+# Tool binary paths (for verification)
+coercion_tools_binaries:
+  responder: "/usr/local/bin/responder"
+  mitm6: "/usr/local/bin/mitm6"
+  coercer: "/usr/local/bin/coercer"
+  petitpotam: "/usr/local/bin/petitpotam"
+  krbrelayx: "/usr/local/bin/krbrelayx"
+  addspn: "/usr/local/bin/addspn"
+  dnstool: "/usr/local/bin/dnstool"
+  ntlmrelayx: "/usr/local/bin/impacket-ntlmrelayx"
+  dfscoerce: "/usr/local/bin/dfscoerce"

--- a/roles/coercion_tools/meta/main.yml
+++ b/roles/coercion_tools/meta/main.yml
@@ -1,0 +1,29 @@
+---
+galaxy_info:
+  role_name: coercion_tools
+  namespace: l50
+  author: Jayson Grace
+  description: Install and configure network poisoning and relay attack tools
+  company: techvomit
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: Kali
+      versions:
+        - all
+  galaxy_tags:
+    - security
+    - pentesting
+    - network
+    - poisoning
+    - relay
+    - kali
+    - offsec
+
+dependencies: []

--- a/roles/coercion_tools/molecule/default/callback_plugins/profile_tasks.py
+++ b/roles/coercion_tools/molecule/default/callback_plugins/profile_tasks.py
@@ -1,0 +1,29 @@
+# molecule/default/callback_plugins/profile_tasks.py
+from ansible.plugins.callback import CallbackBase
+import time
+
+class CallbackModule(CallbackBase):
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_NAME = 'profile_tasks'
+    CALLBACK_NEEDS_WHITELIST = False
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+        self.stats = {}
+
+    def v2_runner_on_ok(self, result, **kwargs):
+        task_name = result._task.get_name()
+        task_time = time.time() - self.start_time
+        if task_name not in self.stats:
+            self.stats[task_name] = []
+        self.stats[task_name].append(task_time)
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        self.start_time = time.time()
+
+    def v2_playbook_on_stats(self, stats):
+        for task_name, timings in self.stats.items():
+            total_time = sum(timings)
+            average_time = total_time / len(timings)
+            print(f"Task: {task_name} - Total Time: {total_time:.2f}s, Average Time: {average_time:.2f}s")

--- a/roles/coercion_tools/molecule/default/converge.yml
+++ b/roles/coercion_tools/molecule/default/converge.yml
@@ -1,0 +1,14 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Include default variables
+      ansible.builtin.include_vars:
+        file: "../../defaults/main.yml"
+
+    - name: Include role under test
+      ansible.builtin.include_role:
+        name: l50.arsenal.coercion_tools
+      vars:
+        coercion_tools_pip_break_system_packages: true

--- a/roles/coercion_tools/molecule/default/create.yml
+++ b/roles/coercion_tools/molecule/default/create.yml
@@ -1,0 +1,41 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    molecule_labels:
+      owner: molecule
+  tasks:
+    - name: Set async_dir for HOME env # noqa: var-naming[no-role-prefix]
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: lookup('env', 'HOME') | length > 0
+
+    - name: Create molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
+        image: "{{ item.image }}"
+        command: "{{ item.command | default('') }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
+      register: coercion_tools_server
+      loop: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: coercion_tools_docker_jobs
+      until: coercion_tools_docker_jobs.finished
+      retries: 300
+      delay: 1
+      loop: "{{ coercion_tools_server.results }}"

--- a/roles/coercion_tools/molecule/default/destroy.yml
+++ b/roles/coercion_tools/molecule/default/destroy.yml
@@ -1,0 +1,14 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+      when: molecule_yml.platforms is defined

--- a/roles/coercion_tools/molecule/default/molecule.yml
+++ b/roles/coercion_tools/molecule/default/molecule.yml
@@ -1,0 +1,37 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: ../../requirements.yml
+    requirements-file: ../../requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: ubuntu-coercion-tools
+    image: "geerlingguy/docker-ubuntu2404-ansible:latest"
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+
+  - name: kali-coercion-tools
+    image: cisagov/docker-kali-ansible:latest
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+
+provisioner:
+  name: ansible
+  config_file: ${MOLECULE_PROJECT_DIRECTORY}/../../ansible.cfg
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+  env:
+    ANSIBLE_CALLBACK_PLUGINS: "${MOLECULE_SCENARIO_DIRECTORY}/callback_plugins"
+
+verifier:
+  name: ansible

--- a/roles/coercion_tools/molecule/default/verify.yml
+++ b/roles/coercion_tools/molecule/default/verify.yml
@@ -1,0 +1,520 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Include default variables
+      ansible.builtin.include_vars:
+        file: "../../defaults/main.yml"
+
+    # Build dependency verification - prevents netifaces/mitm6 compilation failures
+    - name: Verify gcc is available (required for compiling Python C extensions)
+      ansible.builtin.command: which gcc
+      register: coercion_tools_gcc_check
+      changed_when: false
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Assert gcc is installed
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_gcc_check.rc == 0
+        fail_msg: "gcc is not installed - required for compiling Python C extensions (httptools, netifaces)"
+        success_msg: "gcc is available at {{ coercion_tools_gcc_check.stdout }}"
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Check build-essential package status
+      ansible.builtin.command: dpkg -s build-essential
+      register: coercion_tools_build_essential_check
+      changed_when: false
+      failed_when: false
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Assert build-essential is installed
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_build_essential_check.rc == 0
+        fail_msg: "build-essential is not installed - required for compiling Python C extensions (httptools, netifaces)"
+        success_msg: "build-essential is installed"
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Check python3-dev package status
+      ansible.builtin.command: dpkg -s python3-dev
+      register: coercion_tools_python3_dev_check
+      changed_when: false
+      failed_when: false
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Assert python3-dev is installed
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_python3_dev_check.rc == 0
+        fail_msg: "python3-dev is not installed - required for compiling Python C extensions (httptools, netifaces)"
+        success_msg: "python3-dev is installed"
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Get Python version for package verification
+      ansible.builtin.command: python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
+      register: coercion_tools_verify_python_version
+      changed_when: false
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Check version-specific python dev package status
+      ansible.builtin.command: dpkg -s python{{ coercion_tools_verify_python_version.stdout }}-dev
+      register: coercion_tools_python_version_dev_check
+      changed_when: false
+      failed_when: false
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Note version-specific python dev package status
+      ansible.builtin.debug:
+        msg: >-
+          python{{ coercion_tools_verify_python_version.stdout }}-dev:
+          {{ 'Installed' if coercion_tools_python_version_dev_check.rc == 0
+             else 'Not available (may be bundled in python3-dev)' }}
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Verify Python.h header exists (confirms python3-dev working)
+      ansible.builtin.shell: |
+        set -o pipefail
+        # Find Python.h in system include paths (handles multiple Python versions)
+        find /usr/include -name "Python.h" -path "*/python3*" 2>/dev/null | head -1 | grep -q .
+      args:
+        executable: /bin/bash
+      register: coercion_tools_python_header_check
+      changed_when: false
+      failed_when: false
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Assert Python development headers are available
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_python_header_check.rc == 0
+        fail_msg: "Python.h header not found - python3-dev may not be properly installed"
+        success_msg: "Python development headers are available"
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Check which Responder command is available
+      ansible.builtin.shell: which responder || which Responder.py || which /root/.local/bin/responder
+      register: coercion_tools_responder_which
+      changed_when: false
+      failed_when: false
+      environment:
+        PATH: "/root/.local/bin:{{ ansible_facts['env']['PATH'] }}"
+      when: coercion_tools_install_responder | default(true)
+
+    - name: Verify Responder is installed
+      ansible.builtin.command: "{{ coercion_tools_responder_which.stdout }} --version"
+      register: coercion_tools_responder_version
+      changed_when: false
+      failed_when: false
+      when:
+        - coercion_tools_install_responder | default(true)
+        - coercion_tools_responder_which.rc == 0
+
+    - name: Assert Responder is available
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_responder_which.rc == 0
+          - coercion_tools_responder_which.stdout is defined
+        fail_msg: "Responder is not properly installed"
+        success_msg: "Responder is installed at {{ coercion_tools_responder_which.stdout }}"
+      when: coercion_tools_install_responder | default(true)
+
+    - name: Verify mitm6 is installed
+      ansible.builtin.command: which mitm6
+      register: coercion_tools_mitm6_check
+      changed_when: false
+      failed_when: false
+      environment:
+        PATH: "/root/.local/bin:{{ ansible_facts['env']['PATH'] }}"
+      when: coercion_tools_install_mitm6 | default(true)
+
+    - name: Get mitm6 version
+      ansible.builtin.command: mitm6 --version
+      register: coercion_tools_mitm6_version
+      changed_when: false
+      failed_when: false
+      environment:
+        PATH: "/root/.local/bin:{{ ansible_facts['env']['PATH'] }}"
+      when:
+        - coercion_tools_install_mitm6 | default(true)
+        - coercion_tools_mitm6_check.rc == 0
+
+    - name: Assert mitm6 is available
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_mitm6_check.rc == 0
+          - coercion_tools_mitm6_check.stdout is defined
+        fail_msg: "mitm6 is not properly installed"
+        success_msg: "mitm6 is installed at {{ coercion_tools_mitm6_check.stdout }}"
+      when: coercion_tools_install_mitm6 | default(true)
+
+    - name: Verify Coercer is installed
+      ansible.builtin.command: which coercer
+      register: coercion_tools_coercer_check
+      changed_when: false
+      failed_when: false
+      environment:
+        PATH: "/root/.local/bin:{{ ansible_facts['env']['PATH'] }}"
+      when: coercion_tools_install_coercer | default(true)
+
+    - name: Get Coercer version
+      ansible.builtin.command: coercer --version
+      register: coercion_tools_coercer_version
+      changed_when: false
+      failed_when: false
+      environment:
+        PATH: "/root/.local/bin:{{ ansible_facts['env']['PATH'] }}"
+      when:
+        - coercion_tools_install_coercer | default(true)
+        - coercion_tools_coercer_check.rc == 0
+
+    - name: Assert Coercer is available
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_coercer_check.rc == 0
+          - coercion_tools_coercer_check.stdout is defined
+        fail_msg: "Coercer is not properly installed"
+        success_msg: "Coercer is installed at {{ coercion_tools_coercer_check.stdout }}"
+      when: coercion_tools_install_coercer | default(true)
+
+    - name: Verify PetitPotam is installed
+      ansible.builtin.stat:
+        path: "{{ coercion_tools_petitpotam_install_dir }}/petitpotam.py"
+      register: coercion_tools_petitpotam_stat
+      when: coercion_tools_install_petitpotam | default(true)
+
+    - name: Assert PetitPotam is available
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_petitpotam_stat.stat.exists
+          - coercion_tools_petitpotam_stat.stat.executable
+        fail_msg: "PetitPotam is not properly installed"
+        success_msg: "PetitPotam is installed at {{ coercion_tools_petitpotam_install_dir }}/petitpotam.py"
+      when: coercion_tools_install_petitpotam | default(true)
+
+    - name: Verify krbrelayx is installed
+      ansible.builtin.stat:
+        path: "{{ coercion_tools_krbrelayx_install_dir }}/krbrelayx.py"
+      register: coercion_tools_krbrelayx_stat
+      when: coercion_tools_install_krbrelayx | default(true)
+
+    - name: Assert krbrelayx is available
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_krbrelayx_stat.stat.exists
+          - coercion_tools_krbrelayx_stat.stat.executable
+        fail_msg: "krbrelayx is not properly installed"
+        success_msg: "krbrelayx is installed at {{ coercion_tools_krbrelayx_install_dir }}/krbrelayx.py"
+      when: coercion_tools_install_krbrelayx | default(true)
+
+    - name: Verify krbrelayx wrapper script exists
+      ansible.builtin.stat:
+        path: /usr/local/bin/krbrelayx
+      register: coercion_tools_krbrelayx_wrapper
+      when: coercion_tools_install_krbrelayx | default(true)
+
+    - name: Assert krbrelayx wrapper is available
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_krbrelayx_wrapper.stat.exists
+          - coercion_tools_krbrelayx_wrapper.stat.executable
+        fail_msg: "krbrelayx wrapper not created at /usr/local/bin/krbrelayx"
+        success_msg: "krbrelayx wrapper is available at /usr/local/bin/krbrelayx"
+      when: coercion_tools_install_krbrelayx | default(true)
+
+    # Verify impacket regsecrets module is available (required for NetExec SMB)
+    - name: Verify impacket regsecrets module in source venv
+      ansible.builtin.command: /opt/impacket/venv/bin/python -c "from impacket.examples import regsecrets; print('OK')"
+      register: coercion_tools_regsecrets_check
+      changed_when: false
+      failed_when: false
+
+    - name: Assert impacket regsecrets module is available
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_regsecrets_check.rc == 0
+        fail_msg: "impacket.examples.regsecrets not found in impacket venv"
+        success_msg: "impacket regsecrets module available in venv"
+
+    - name: Check impacket is installed in krbrelayx venv
+      ansible.builtin.command: "{{ coercion_tools_krbrelayx_install_dir }}/venv/bin/pip show impacket"
+      register: coercion_tools_krbrelayx_impacket
+      changed_when: false
+      failed_when: false
+      when: coercion_tools_install_krbrelayx | default(true)
+
+    - name: Assert impacket is installed in krbrelayx venv
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_krbrelayx_impacket.rc == 0
+        fail_msg: "impacket is not installed in krbrelayx venv (required for printerbug.py)"
+        success_msg: "impacket is installed in krbrelayx venv"
+      when: coercion_tools_install_krbrelayx | default(true)
+
+    - name: Verify ntlmrelayx wrapper script exists
+      ansible.builtin.stat:
+        path: /usr/local/bin/ntlmrelayx
+      register: coercion_tools_ntlmrelayx_wrapper
+      when: coercion_tools_install_ntlmrelayx | default(true)
+
+    - name: Verify ntlmrelayx.py exists
+      ansible.builtin.stat:
+        path: /usr/local/bin/ntlmrelayx.py
+      register: coercion_tools_ntlmrelayx_py
+      when: coercion_tools_install_ntlmrelayx | default(true)
+
+    - name: Assert ntlmrelayx wrapper is available
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_ntlmrelayx_wrapper.stat.exists
+          - coercion_tools_ntlmrelayx_wrapper.stat.executable
+          - coercion_tools_ntlmrelayx_py.stat.exists
+        fail_msg: "ntlmrelayx wrapper not created at /usr/local/bin/ntlmrelayx"
+        success_msg: "ntlmrelayx wrapper is available at /usr/local/bin/ntlmrelayx"
+      when: coercion_tools_install_ntlmrelayx | default(true)
+
+    # Regression guard: if these scripts ever revert to raw Python copies with a
+    # `#!/usr/bin/python3` shebang, they will crash with `ModuleNotFoundError:
+    # No module named 'pkg_resources'` on Debian trixie (Python 3.13). The
+    # wrappers must be bash dispatchers that invoke the impacket venv Python.
+    - name: Read first line of /usr/local/bin/ntlmrelayx.py to confirm bash wrapper
+      ansible.builtin.command: head -n 1 /usr/local/bin/ntlmrelayx.py
+      register: coercion_tools_ntlmrelayx_py_shebang
+      changed_when: false
+      when: coercion_tools_install_ntlmrelayx | default(true)
+
+    - name: Assert /usr/local/bin/ntlmrelayx.py is a bash wrapper (not a raw Python copy)
+      ansible.builtin.assert:
+        that:
+          - "'#!/bin/bash' in coercion_tools_ntlmrelayx_py_shebang.stdout"
+        fail_msg: >-
+          /usr/local/bin/ntlmrelayx.py has shebang
+          '{{ coercion_tools_ntlmrelayx_py_shebang.stdout }}' — expected
+          '#!/bin/bash'. A raw Python copy here will crash on Python 3.13 with
+          ModuleNotFoundError: pkg_resources and break the entire coerce -> relay
+          chain.
+        success_msg: "/usr/local/bin/ntlmrelayx.py is a venv-aware bash wrapper"
+      when: coercion_tools_install_ntlmrelayx | default(true)
+
+    # Functional smoke test: actually invoke the impacket entrypoints. This is
+    # the assertion that catches the pkg_resources regression — a raw copy
+    # would exit non-zero immediately on Python 3.13.
+    - name: Run --help on representative impacket entrypoints to catch import-time crashes
+      ansible.builtin.command: "{{ item }} --help"
+      register: coercion_tools_impacket_help_runs
+      changed_when: false
+      failed_when: coercion_tools_impacket_help_runs.rc != 0
+      loop:
+        - /usr/local/bin/ntlmrelayx.py
+        - /usr/local/bin/secretsdump.py
+        - /usr/local/bin/psexec.py
+        - /usr/local/bin/smbexec.py
+        - /usr/local/bin/wmiexec.py
+        - /usr/local/bin/mssqlclient.py
+        - /usr/local/bin/GetUserSPNs.py
+        - /usr/local/bin/GetNPUsers.py
+        - /usr/local/bin/rbcd.py
+        - /usr/local/bin/addcomputer.py
+        - /usr/local/bin/impacket-ntlmrelayx
+      when: coercion_tools_install_ntlmrelayx | default(true)
+
+    # Regression guard for petitpotam / coercer / dfscoerce / printerbug:
+    # petitpotam.py upstream uses `#!/usr/bin/python3` (system interpreter)
+    # and imports impacket.version. On Debian trixie the only system-wide
+    # impacket is the 0.10.0 transitive dep that pip pulls in for the
+    # coercer package, and impacket/version.py crashes on `import
+    # pkg_resources` because setuptools isn't installed for the system
+    # Python. Kali ships python3-pkg-resources so a plain symlink to the
+    # raw .py works there; non-Kali needs a venv-aware bash wrapper.
+    # Asserting --help exits 0 catches the regression class for every
+    # coercion entrypoint on both distros regardless of launcher strategy.
+    - name: Read first line of /usr/local/bin/petitpotam to confirm bash wrapper (non-Kali)
+      ansible.builtin.command: head -n 1 /usr/local/bin/petitpotam
+      register: coercion_tools_petitpotam_shebang
+      changed_when: false
+      when:
+        - coercion_tools_install_petitpotam | default(true)
+        - ansible_facts['distribution'] != 'Kali'
+
+    - name: Assert /usr/local/bin/petitpotam is a bash wrapper (non-Kali)
+      ansible.builtin.assert:
+        that:
+          - "'#!/bin/bash' in coercion_tools_petitpotam_shebang.stdout"
+        fail_msg: >-
+          /usr/local/bin/petitpotam has shebang
+          '{{ coercion_tools_petitpotam_shebang.stdout }}' — expected
+          '#!/bin/bash'. A symlink to the upstream petitpotam.py runs under
+          the system Python, which on Debian trixie crashes with
+          ModuleNotFoundError: pkg_resources at import time.
+        success_msg: "/usr/local/bin/petitpotam is a venv-aware bash wrapper"
+      when:
+        - coercion_tools_install_petitpotam | default(true)
+        - ansible_facts['distribution'] != 'Kali'
+
+    - name: Stat /usr/local/bin/petitpotam launcher (Kali)
+      ansible.builtin.stat:
+        path: /usr/local/bin/petitpotam
+        follow: false
+      register: coercion_tools_petitpotam_kali_launcher
+      when:
+        - coercion_tools_install_petitpotam | default(true)
+        - ansible_facts['distribution'] == 'Kali'
+
+    - name: Assert /usr/local/bin/petitpotam is a symlink to petitpotam.py (Kali)
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_petitpotam_kali_launcher.stat.islnk | default(false)
+          - coercion_tools_petitpotam_kali_launcher.stat.lnk_target
+            == coercion_tools_petitpotam_install_dir ~ '/petitpotam.py'
+        fail_msg: >-
+          /usr/local/bin/petitpotam is not a symlink pointing at
+          '{{ coercion_tools_petitpotam_install_dir }}/petitpotam.py'
+          (islnk={{ coercion_tools_petitpotam_kali_launcher.stat.islnk | default(false) }},
+          target='{{ coercion_tools_petitpotam_kali_launcher.stat.lnk_target | default('') }}').
+        success_msg: "/usr/local/bin/petitpotam is a symlink to petitpotam.py"
+      when:
+        - coercion_tools_install_petitpotam | default(true)
+        - ansible_facts['distribution'] == 'Kali'
+
+    - name: Run --help on coercion entrypoints to catch import-time crashes
+      ansible.builtin.command: "{{ item }} --help"
+      register: coercion_tools_coerce_help_runs
+      changed_when: false
+      failed_when: coercion_tools_coerce_help_runs.rc != 0
+      loop:
+        - /usr/local/bin/petitpotam
+        # Coercer lives at /usr/local/bin on pip installs (Ubuntu) but at
+        # /usr/bin when installed from apt (Kali), so use the path that
+        # `which coercer` actually resolved above instead of hard-coding it.
+        - "{{ coercion_tools_coercer_check.stdout | default('coercer', true) }}"
+        - /usr/local/bin/dfscoerce
+        - /usr/local/bin/printerbug
+      when:
+        - coercion_tools_install_petitpotam | default(true)
+        - coercion_tools_install_coercer | default(true)
+        - coercion_tools_install_dfscoerce | default(true)
+        - coercion_tools_install_krbrelayx | default(true)
+
+    - name: Verify dfscoerce is installed
+      ansible.builtin.stat:
+        path: "{{ coercion_tools_dfscoerce_install_dir }}/dfscoerce.py"
+      register: coercion_tools_dfscoerce_stat
+      when: coercion_tools_install_dfscoerce | default(true)
+
+    - name: Verify dfscoerce wrapper exists
+      ansible.builtin.stat:
+        path: /usr/local/bin/dfscoerce
+      register: coercion_tools_dfscoerce_wrapper
+      when: coercion_tools_install_dfscoerce | default(true)
+
+    - name: Assert dfscoerce is available
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_dfscoerce_stat.stat.exists
+          - coercion_tools_dfscoerce_wrapper.stat.exists
+        fail_msg: "dfscoerce is not properly installed"
+        success_msg: "dfscoerce is installed at {{ coercion_tools_dfscoerce_install_dir }}/dfscoerce.py"
+      when: coercion_tools_install_dfscoerce | default(true)
+
+    - name: Test Responder help output
+      ansible.builtin.shell: set -o pipefail && {{ coercion_tools_responder_which.stdout }} --help 2>&1 | head -5
+      register: coercion_tools_responder_test
+      changed_when: false
+      failed_when: false
+      environment:
+        PATH: "/root/.local/bin:{{ ansible_facts['env']['PATH'] }}"
+      args:
+        executable: /bin/bash
+      when:
+        - coercion_tools_install_responder | default(true)
+        - coercion_tools_responder_which.rc == 0
+
+    - name: Assert Responder is functional
+      ansible.builtin.assert:
+        that:
+          - coercion_tools_responder_test.rc != 127
+        fail_msg: "Responder is not functioning (rc={{ coercion_tools_responder_test.rc }})"
+        success_msg: "Responder is functional"
+      when:
+        - coercion_tools_install_responder | default(true)
+        - coercion_tools_responder_which.rc == 0
+
+    - name: Display verification summary
+      ansible.builtin.debug:
+        msg:
+          - "=== Coercion Tools Verification Complete ==="
+          - "--- Build Dependencies ---"
+          - >-
+            gcc:
+            {{ coercion_tools_gcc_check.stdout
+               if coercion_tools_gcc_check is defined and coercion_tools_gcc_check.rc == 0
+               else 'Not installed' }}
+          - >-
+            build-essential:
+            {{ 'Installed'
+               if coercion_tools_build_essential_check is defined
+                  and coercion_tools_build_essential_check.rc == 0
+               else 'Not installed' }}
+          - >-
+            python3-dev:
+            {{ 'Installed'
+               if coercion_tools_python3_dev_check is defined
+                  and coercion_tools_python3_dev_check.rc == 0
+               else 'Not installed' }}
+          - >-
+            python{{ coercion_tools_verify_python_version.stdout }}-dev:
+            {{ 'Installed'
+               if coercion_tools_python_version_dev_check is defined
+                  and coercion_tools_python_version_dev_check.rc == 0
+               else 'Not installed' }}
+          - "--- Tools ---"
+          - >-
+            Responder:
+            {{ coercion_tools_responder_which.stdout
+               if coercion_tools_responder_which is defined
+                  and coercion_tools_responder_which.rc == 0
+               else 'Not installed' }}
+          - >-
+            mitm6:
+            {{ coercion_tools_mitm6_check.stdout
+               if coercion_tools_mitm6_check is defined
+                  and coercion_tools_mitm6_check.rc == 0
+               else 'Not installed' }}
+          - >-
+            Coercer:
+            {{ coercion_tools_coercer_check.stdout
+               if coercion_tools_coercer_check is defined
+                  and coercion_tools_coercer_check.rc == 0
+               else 'Not installed' }}
+          - >-
+            PetitPotam:
+            {{ 'Installed'
+               if coercion_tools_petitpotam_stat is defined
+                  and coercion_tools_petitpotam_stat.stat.exists
+               else 'Not installed' }}
+          - >-
+            krbrelayx:
+            {{ 'Installed'
+               if coercion_tools_krbrelayx_stat is defined
+                  and coercion_tools_krbrelayx_stat.stat.exists
+               else 'Not installed' }}
+          - >-
+            krbrelayx impacket:
+            {{ 'Installed'
+               if coercion_tools_krbrelayx_impacket is defined
+                  and coercion_tools_krbrelayx_impacket.rc == 0
+               else 'Not installed' }}
+          - >-
+            ntlmrelayx wrapper:
+            {{ 'Installed'
+               if coercion_tools_ntlmrelayx_wrapper is defined
+                  and coercion_tools_ntlmrelayx_wrapper.stat.exists
+               else 'Not installed' }}
+          - >-
+            dfscoerce:
+            {{ 'Installed'
+               if coercion_tools_dfscoerce_stat is defined
+                  and coercion_tools_dfscoerce_stat.stat.exists
+               else 'Not installed' }}
+          - "===================================================="

--- a/roles/coercion_tools/tasks/impacket_source.yml
+++ b/roles/coercion_tools/tasks/impacket_source.yml
@@ -1,0 +1,205 @@
+---
+# Install Impacket from GitHub source
+# Pulls the latest examples (including regsecrets) for relay and delegation tooling
+# Reference: https://github.com/fortra/impacket
+
+- name: Install git for cloning impacket
+  ansible.builtin.apt:
+    name: git
+    state: present
+  become: true
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Remove conflicting apt impacket packages (Ubuntu only - Kali netexec depends on them)
+  ansible.builtin.apt:
+    name:
+      - python3-impacket
+      - impacket-scripts
+    state: absent
+    purge: true
+  become: true
+  failed_when: false
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+
+- name: Check if impacket is installed from source
+  ansible.builtin.stat:
+    path: "{{ coercion_tools_impacket_install_dir }}/impacket/__init__.py"
+  register: coercion_tools_impacket_source_check
+
+- name: Check if impacket repo already exists
+  ansible.builtin.stat:
+    path: "{{ coercion_tools_impacket_install_dir }}/.git"
+  register: coercion_tools_impacket_git_check
+
+- name: Clone impacket repository from GitHub (initial clone)
+  ansible.builtin.git:
+    repo: "{{ coercion_tools_impacket_repo }}"
+    dest: "{{ coercion_tools_impacket_install_dir }}"
+    version: "{{ coercion_tools_impacket_version }}"
+  become: true
+  register: coercion_tools_impacket_clone
+  when: not coercion_tools_impacket_git_check.stat.exists
+
+- name: Set impacket venv path
+  ansible.builtin.set_fact:
+    coercion_tools_impacket_venv: "{{ coercion_tools_impacket_install_dir }}/venv"
+
+- name: Check if impacket venv exists
+  ansible.builtin.stat:
+    path: "{{ coercion_tools_impacket_venv }}/bin/python"
+  register: coercion_tools_impacket_venv_check
+
+- name: Check if we need to install or reinstall impacket
+  ansible.builtin.set_fact:
+    coercion_tools_needs_impacket_install: >-
+      {{
+        (not coercion_tools_impacket_venv_check.stat.exists)
+        or (coercion_tools_impacket_clone.changed | default(false))
+      }}
+    coercion_tools_force_impacket_reinstall: >-
+      {{
+        (coercion_tools_impacket_clone.changed | default(false))
+      }}
+
+- name: Create impacket virtual environment
+  ansible.builtin.command:
+    cmd: "python3 -m venv {{ coercion_tools_impacket_venv }}"
+  become: true
+  args:
+    creates: "{{ coercion_tools_impacket_venv }}/bin/python"
+  when: coercion_tools_needs_impacket_install | bool
+
+- name: Install impacket from source
+  ansible.builtin.pip:
+    name: "{{ coercion_tools_impacket_install_dir }}"
+    virtualenv: "{{ coercion_tools_impacket_venv }}"
+    editable: true
+    # Use forcereinstall when we removed the wrong installation or git repo changed
+    # Otherwise use present for idempotent behavior (won't reinstall if already installed)
+    state: "{{ 'forcereinstall' if coercion_tools_force_impacket_reinstall else 'present' }}"
+    # Add --ignore-installed when force reinstalling to handle cached packages in the venv.
+    extra_args: "{{ '--ignore-installed' if coercion_tools_force_impacket_reinstall else '' }}"
+  become: true
+  register: coercion_tools_impacket_install
+  when: coercion_tools_needs_impacket_install | bool
+
+- name: Upgrade pycryptodome in impacket venv (CVE fix - GHSA-j225-cvw7-qrx7)
+  ansible.builtin.pip:
+    name: "pycryptodome>=3.19.1"
+    virtualenv: "{{ coercion_tools_impacket_venv }}"
+    state: latest  # noqa: package-latest - pinned via version spec; keeps ahead of CVE fix
+  become: true
+  when: coercion_tools_needs_impacket_install | bool
+
+- name: Check if impacket is correctly installed in venv
+  ansible.builtin.command: "{{ coercion_tools_impacket_venv }}/bin/python -c \"import impacket; print(impacket.__file__)\""
+  register: coercion_tools_impacket_import_check
+  changed_when: false
+  failed_when: false
+
+- name: Make impacket example scripts executable
+  ansible.builtin.shell: |
+    chmod +x {{ coercion_tools_impacket_install_dir }}/examples/*.py
+  args:
+    executable: /bin/bash
+  become: true
+  changed_when: false
+
+- name: Check if \_\_init\_\_.py exists in impacket/examples
+  ansible.builtin.stat:
+    path: "{{ coercion_tools_impacket_install_dir }}/impacket/examples/__init__.py"
+  register: coercion_tools_impacket_init_check
+
+- name: Create \_\_init\_\_.py in impacket/examples to make it a proper Python package
+  ansible.builtin.copy:
+    content: "# Auto-generated __init__.py to make impacket.examples importable\n# Required for NetExec SMB functionality (regsecrets module)\n"
+    dest: "{{ coercion_tools_impacket_install_dir }}/impacket/examples/__init__.py"
+    mode: '0644'
+  become: true
+  when: not coercion_tools_impacket_init_check.stat.exists
+
+- name: Check system impacket version (Kali)
+  ansible.builtin.command: python3 -c "import importlib.metadata; print(importlib.metadata.version('impacket'))"
+  register: coercion_tools_system_impacket_version
+  changed_when: false
+  failed_when: false
+  when:
+    - ansible_facts['distribution'] == 'Kali'
+
+- name: Install source impacket into system Python (Kali apt netexec needs it system-wide)
+  ansible.builtin.pip:
+    name: "{{ coercion_tools_impacket_install_dir }}"
+    executable: pip3
+    editable: true
+    state: forcereinstall
+    extra_args: "--break-system-packages --ignore-installed"
+  become: true
+  when:
+    - ansible_facts['distribution'] == 'Kali'
+    - (coercion_tools_system_impacket_version.stdout | default('0.0.0', true)) is version('0.13.0', '<')
+      or coercion_tools_impacket_clone.changed | default(false)
+
+- name: Enumerate impacket example scripts
+  ansible.builtin.find:
+    paths: "{{ coercion_tools_impacket_install_dir }}/examples"
+    patterns: "*.py"
+    file_type: file
+  register: coercion_tools_impacket_examples
+
+- name: Fail loudly if impacket examples were not found
+  ansible.builtin.assert:
+    that:
+      - coercion_tools_impacket_examples.files | length > 0
+    fail_msg: >-
+      No impacket example scripts found under
+      {{ coercion_tools_impacket_install_dir }}/examples — clone likely
+      failed or the upstream layout changed. Refusing to continue so the
+      coercion image cannot ship with broken or missing ntlmrelayx wrappers.
+
+# Always (re)write the bash wrappers. Both /usr/local/bin/<tool>.py and
+# /usr/local/bin/impacket-<tool> must dispatch through the impacket venv
+# so the tools never inherit the system Python (which on Debian trixie /
+# Python 3.13 lacks pkg_resources and crashes immediately).
+- name: Install venv-aware bash wrappers for impacket example scripts (no .py suffix)
+  ansible.builtin.copy:
+    dest: "/usr/local/bin/impacket-{{ (item.path | basename | splitext)[0] }}"
+    mode: '0755'
+    content: |
+      #!/bin/bash
+      exec "{{ coercion_tools_impacket_venv }}/bin/python" "{{ item.path }}" "$@"
+  become: true
+  loop: "{{ coercion_tools_impacket_examples.files }}"
+  loop_control:
+    label: "impacket-{{ (item.path | basename | splitext)[0] }}"
+
+- name: Install venv-aware bash wrappers for impacket example scripts (.py suffix)
+  ansible.builtin.copy:
+    dest: "/usr/local/bin/{{ item.path | basename }}"
+    mode: '0755'
+    content: |
+      #!/bin/bash
+      exec "{{ coercion_tools_impacket_venv }}/bin/python" "{{ item.path }}" "$@"
+  become: true
+  loop: "{{ coercion_tools_impacket_examples.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+
+- name: Verify impacket regsecrets module is available
+  ansible.builtin.command: "{{ coercion_tools_impacket_venv }}/bin/python -c \"from impacket.examples import regsecrets; print('regsecrets module OK')\""
+  register: coercion_tools_regsecrets_check
+  changed_when: false
+  failed_when: false
+
+- name: Report impacket installation status
+  ansible.builtin.debug:
+    msg: |
+      Impacket installation from source: {{
+        'SUCCESS' if coercion_tools_impacket_install.changed | default(false)
+                  or not coercion_tools_impacket_install.failed | default(false)
+        else 'FAILED'
+      }}
+      Impacket version: {{ coercion_tools_impacket_version }}
+      regsecrets module: {{ 'AVAILABLE' if coercion_tools_regsecrets_check.rc == 0 else 'NOT FOUND' }}
+      Install directory: {{ coercion_tools_impacket_install_dir }}

--- a/roles/coercion_tools/tasks/linux.yml
+++ b/roles/coercion_tools/tasks/linux.yml
@@ -1,0 +1,391 @@
+---
+- name: Wait for apt locks to be released
+  ansible.builtin.shell: |
+    while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || \
+          fuser /var/lib/dpkg/lock >/dev/null 2>&1 || \
+          fuser /var/cache/apt/archives/lock >/dev/null 2>&1; do
+      echo "Waiting for apt locks to be released..."
+      sleep 2
+    done
+  become: true
+  changed_when: false
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Set DEBIAN_FRONTEND to noninteractive
+  ansible.builtin.lineinfile:
+    path: /etc/environment
+    line: 'DEBIAN_FRONTEND=noninteractive'
+    create: true
+    mode: '0644'
+  become: true
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+  become: true
+  when:
+    - coercion_tools_update_cache
+    - ansible_facts['os_family'] == 'Debian'
+
+- name: Remove conflicting python3-responder package on Kali
+  ansible.builtin.apt:
+    name: python3-responder
+    state: absent
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] == 'Kali'
+    - coercion_tools_install_responder
+
+- name: Install Kali-specific poisoning tools (includes responder from apt)
+  ansible.builtin.apt:
+    name: "{{ coercion_tools_kali_packages }}"
+    state: present
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] == 'Kali'
+
+- name: Install Ubuntu-compatible dependencies
+  ansible.builtin.apt:
+    name: "{{ coercion_tools_ubuntu_packages }}"
+    state: present
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+
+# On non-Kali (Ubuntu/Debian), Coercer must be installed BEFORE
+# impacket_source.yml. `pip install coercer` drags in its own impacket as
+# a dependency, which drops upstream example scripts (ntlmrelayx.py,
+# secretsdump.py, ...) into /usr/local/bin wired to the system Python.
+# Those get overwritten by the venv-aware bash wrappers from
+# impacket_source.yml, so Coercer has to run first — otherwise it
+# clobbers the wrappers, leaving the tools pointed at a broken system
+# interpreter and making the converge non-idempotent.
+- name: Check if Coercer is already installed (non-Kali)
+  ansible.builtin.command: pip3 show coercer
+  register: coercion_tools_coercer_check
+  changed_when: false
+  failed_when: false
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+    - coercion_tools_install_coercer
+
+- name: Install Coercer via pip (non-Kali)
+  ansible.builtin.pip:
+    name: "{{ coercion_tools_coercer_package }}"
+    executable: pip3
+    # Use --ignore-installed to handle system packages that can't be uninstalled
+    extra_args: "{{ ('--break-system-packages ' if (coercion_tools_pip_break_system_packages | default(false)) else '') ~ '--ignore-installed' }}"
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+    - coercion_tools_install_coercer
+    - coercion_tools_coercer_check.rc != 0
+
+- name: Install Impacket from source for ntlmrelayx
+  ansible.builtin.include_tasks: impacket_source.yml
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - coercion_tools_install_ntlmrelayx
+    - coercion_tools_impacket_from_source
+
+- name: Check for ntlmrelayx.py wrapper
+  ansible.builtin.stat:
+    path: /usr/local/bin/ntlmrelayx.py
+  register: coercion_tools_ntlmrelayx_py
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - coercion_tools_install_ntlmrelayx
+
+- name: Create ntlmrelayx wrapper script
+  ansible.builtin.copy:
+    content: |
+      #!/bin/sh
+      exec /usr/local/bin/ntlmrelayx.py "$@"
+    dest: /usr/local/bin/ntlmrelayx
+    mode: '0755'
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - coercion_tools_install_ntlmrelayx
+    - coercion_tools_ntlmrelayx_py.stat.exists | default(false)
+
+- name: Clone Responder from GitHub
+  ansible.builtin.git:
+    repo: "{{ coercion_tools_responder_repo }}"
+    dest: "{{ coercion_tools_responder_install_dir }}"
+    version: "{{ coercion_tools_responder_version }}"
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+    - coercion_tools_install_responder
+
+# Install Responder Python dependencies
+- name: Check if Responder dependencies are installed
+  ansible.builtin.command: python3 -c "import cryptography, netifaces, aioquic"
+  register: coercion_tools_responder_deps_check
+  changed_when: false
+  failed_when: false
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+    - coercion_tools_install_responder
+
+- name: Install Responder dependencies (non-Kali)
+  ansible.builtin.pip:
+    name:
+      - netifaces
+      - aioquic
+      - certifi
+      - cryptography>=44.0.1
+      - pylsqpack>=0.3.3,<0.4.0
+      - pyopenssl>=26.0.0
+      - service-identity>=24.1.0
+    executable: pip3
+    # Use --ignore-installed to handle system packages (e.g., cryptography)
+    # that can't be uninstalled because they were installed by apt (no RECORD file)
+    extra_args: "{{ ('--break-system-packages ' if (coercion_tools_pip_break_system_packages | default(false)) else '') ~ '--ignore-installed' }}"
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+    - coercion_tools_install_responder
+    - coercion_tools_responder_deps_check.rc != 0
+
+- name: Make Responder.py executable
+  ansible.builtin.file:
+    path: "{{ coercion_tools_responder_install_dir }}/Responder.py"
+    mode: '0755'
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+    - coercion_tools_install_responder
+
+- name: Create symlink for Responder
+  ansible.builtin.file:
+    src: "{{ coercion_tools_responder_install_dir }}/Responder.py"
+    dest: "/usr/local/bin/responder"
+    state: link
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+    - coercion_tools_install_responder
+
+- name: Install mitm6 via venv (non-Kali)
+  ansible.builtin.include_tasks: mitm6_venv.yml
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+    - coercion_tools_install_mitm6
+
+- name: Install mitm6 via apt (Kali)
+  ansible.builtin.apt:
+    name: "{{ coercion_tools_mitm6_package }}"
+    state: present
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] == 'Kali'
+    - coercion_tools_install_mitm6
+
+- name: Install Coercer via apt (Kali)
+  ansible.builtin.apt:
+    name: "{{ coercion_tools_coercer_package }}"
+    state: present
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] == 'Kali'
+    - coercion_tools_install_coercer
+
+- name: Clone PetitPotam from GitHub (ly4k's improved version)
+  ansible.builtin.git:
+    repo: "{{ coercion_tools_petitpotam_repo }}"
+    dest: "{{ coercion_tools_petitpotam_install_dir }}"
+    version: "{{ coercion_tools_petitpotam_version }}"
+    force: true
+  become: true
+  register: coercion_tools_petitpotam_clone
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - coercion_tools_install_petitpotam
+
+- name: Make petitpotam.py executable
+  ansible.builtin.file:
+    path: "{{ coercion_tools_petitpotam_install_dir }}/petitpotam.py"
+    mode: '0755'
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - coercion_tools_install_petitpotam
+    - coercion_tools_petitpotam_clone is not skipped
+
+- name: Create symlink for PetitPotam (Kali)
+  ansible.builtin.file:
+    src: "{{ coercion_tools_petitpotam_install_dir }}/petitpotam.py"
+    dest: "/usr/local/bin/petitpotam"
+    state: link
+    force: true
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] == 'Kali'
+    - coercion_tools_install_petitpotam
+    - coercion_tools_petitpotam_clone is not skipped
+
+# petitpotam.py ships with `#!/usr/bin/python3` and does
+# `from impacket import system_errors, version`. On Debian trixie /
+# Python 3.13 (and Ubuntu with system-managed Python), the only
+# system-wide impacket is whatever the coercer pip install pulled in,
+# and impacket/version.py does `import pkg_resources` — which fails when
+# setuptools isn't installed in the system interpreter, crashing every
+# petitpotam invocation before argv is parsed. Route through the
+# impacket source venv (setuptools + impacket 0.13.0) instead. Kali has
+# python3-pkg-resources preinstalled, so the plain symlink above is
+# fine there.
+- name: Stat existing PetitPotam launcher (non-Kali)
+  ansible.builtin.stat:
+    path: /usr/local/bin/petitpotam
+    follow: false
+  register: coercion_tools_petitpotam_launcher
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+    - coercion_tools_install_petitpotam
+
+# Only clear out a legacy symlink (the previous implementation symlinked
+# petitpotam.py here). Once the wrapper is in place it is a regular file,
+# so the copy below handles it idempotently.
+- name: Remove legacy PetitPotam symlink so the wrapper can replace it
+  ansible.builtin.file:
+    path: /usr/local/bin/petitpotam
+    state: absent
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+    - coercion_tools_install_petitpotam
+    - coercion_tools_petitpotam_launcher.stat.islnk | default(false)
+
+- name: Install venv-aware bash wrapper for PetitPotam (non-Kali)
+  ansible.builtin.copy:
+    dest: /usr/local/bin/petitpotam
+    mode: '0755'
+    content: |
+      #!/bin/bash
+      exec "{{ coercion_tools_impacket_venv | default(coercion_tools_impacket_install_dir ~ '/venv') }}/bin/python" \
+           "{{ coercion_tools_petitpotam_install_dir }}/petitpotam.py" "$@"
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+    - coercion_tools_install_petitpotam
+    - coercion_tools_install_ntlmrelayx
+    - coercion_tools_impacket_from_source
+
+# krbrelayx - Kerberos relay attacks (alternative to ntlmrelayx for Kerberos)
+- name: Clone krbrelayx from GitHub
+  ansible.builtin.git:
+    repo: "{{ coercion_tools_krbrelayx_repo }}"
+    dest: "{{ coercion_tools_krbrelayx_install_dir }}"
+    version: "{{ coercion_tools_krbrelayx_version }}"
+    update: true
+  become: true
+  register: coercion_tools_krbrelayx_clone
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - coercion_tools_install_krbrelayx
+
+- name: Configure git to ignore filemode changes in krbrelayx repo  # noqa: command-instead-of-module
+  ansible.builtin.command:
+    cmd: git config core.filemode false
+    chdir: "{{ coercion_tools_krbrelayx_install_dir }}"
+  become: true
+  changed_when: false
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - coercion_tools_install_krbrelayx
+    - coercion_tools_krbrelayx_clone is not skipped
+
+- name: Create virtual environment for krbrelayx
+  ansible.builtin.command:
+    cmd: python3 -m venv {{ coercion_tools_krbrelayx_install_dir }}/venv
+  become: true
+  args:
+    creates: "{{ coercion_tools_krbrelayx_install_dir }}/venv"
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - coercion_tools_install_krbrelayx
+
+- name: Install krbrelayx dependencies in venv
+  ansible.builtin.pip:
+    name:
+      - dnspython
+      - ldap3
+      - impacket
+    virtualenv: "{{ coercion_tools_krbrelayx_install_dir }}/venv"
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - coercion_tools_install_krbrelayx
+
+- name: Create wrapper scripts for krbrelayx tools
+  ansible.builtin.copy:
+    content: |
+      #!/bin/bash
+      exec {{ coercion_tools_krbrelayx_install_dir }}/venv/bin/python \
+           {{ coercion_tools_krbrelayx_install_dir }}/{{ item.src }} "$@"
+    dest: "/usr/local/bin/{{ item.dest }}"
+    mode: '0755'
+  become: true
+  loop:
+    - { src: "krbrelayx.py", dest: "krbrelayx" }
+    - { src: "addspn.py", dest: "addspn" }
+    - { src: "dnstool.py", dest: "dnstool" }
+    - { src: "printerbug.py", dest: "printerbug" }
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - coercion_tools_install_krbrelayx
+
+- name: Clone dfscoerce from GitHub
+  ansible.builtin.git:
+    repo: "{{ coercion_tools_dfscoerce_repo }}"
+    dest: "{{ coercion_tools_dfscoerce_install_dir }}"
+    version: "{{ coercion_tools_dfscoerce_version }}"
+    update: false
+  become: true
+  register: coercion_tools_dfscoerce_clone
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - coercion_tools_install_dfscoerce
+
+- name: Make dfscoerce.py executable
+  ansible.builtin.file:
+    path: "{{ coercion_tools_dfscoerce_install_dir }}/dfscoerce.py"
+    mode: '0755'
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - coercion_tools_install_dfscoerce
+    - coercion_tools_dfscoerce_clone is not skipped
+
+- name: Create symlink for dfscoerce
+  ansible.builtin.file:
+    src: "{{ coercion_tools_dfscoerce_install_dir }}/dfscoerce.py"
+    dest: "/usr/local/bin/dfscoerce"
+    state: link
+    force: true
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - coercion_tools_install_dfscoerce
+    - coercion_tools_dfscoerce_clone is not skipped

--- a/roles/coercion_tools/tasks/main.yml
+++ b/roles/coercion_tools/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Include Linux tasks
+  ansible.builtin.include_tasks: linux.yml
+  when: ansible_os_family != 'Windows'

--- a/roles/coercion_tools/tasks/mitm6_venv.yml
+++ b/roles/coercion_tools/tasks/mitm6_venv.yml
@@ -1,0 +1,25 @@
+---
+- name: Install mitm6 in an isolated virtualenv
+  ansible.builtin.pip:
+    name: mitm6
+    virtualenv: "{{ coercion_tools_mitm6_install_dir }}/venv"
+    virtualenv_command: python3 -m venv
+  become: true
+
+- name: Create wrapper script for mitm6
+  ansible.builtin.copy:
+    content: |
+      #!/bin/bash
+      exec {{ coercion_tools_mitm6_install_dir }}/venv/bin/mitm6 "$@"
+    dest: /usr/local/bin/mitm6
+    mode: '0755'
+  become: true
+
+- name: Symlink mitm6 into /usr/bin
+  ansible.builtin.file:
+    src: /usr/local/bin/mitm6
+    dest: /usr/bin/mitm6
+    state: link
+    force: true
+    follow: false
+  become: true


### PR DESCRIPTION
**Key Changes:**

- Introduced a new `coercion_tools` role that installs and configures a full suite of network poisoning and authentication relay attack tools (Responder, mitm6, Coercer, PetitPotam, krbrelayx, ntlmrelayx via Impacket, and DFSCoerce)
- Impacket is installed from source into an isolated virtualenv with venv-aware bash wrappers to prevent `pkg_resources` import crashes on Python 3.13 / Debian trixie
- Comprehensive Molecule test suite added with 520-line verification playbook covering build dependencies, tool presence, shebang regression guards, and functional smoke tests across Ubuntu and Kali platforms
- CI matrix and README updated to include the new role alongside existing collection members

**Added:**

- `coercion_tools` role - Full role scaffold including `defaults/main.yml` with all configurable variables (tool versions, install dirs, binary paths, per-distro package lists), `meta/main.yml` with Galaxy metadata, and `tasks/main.yml` entry point gating on non-Windows OS family
- Linux task orchestration - `tasks/linux.yml` handles distro-aware installation: apt packages for Kali (including Responder, mitm6, Coercer from apt), pip/git-based installs for Ubuntu/Debian, with explicit ordering to prevent Coercer's transitive impacket dep from clobbering venv-aware wrappers
- Impacket source installation - `tasks/impacket_source.yml` clones fortra/impacket at a pinned version, builds an isolated venv, upgrades pycryptodome (CVE GHSA-j225-cvw7-qrx7), creates `impacket/examples/__init__.py` for NetExec SMB compatibility, and writes bash wrappers for every example script under both `impacket-<tool>` and `<tool>.py` naming conventions
- mitm6 venv isolation - `tasks/mitm6_venv.yml` installs mitm6 into its own virtualenv with a wrapper script and `/usr/bin` symlink to avoid dependency conflicts
- Molecule test infrastructure - `molecule/default/` scenario with Docker platforms for both `geerlingguy/docker-ubuntu2404-ansible` and `cisagov/docker-kali-ansible`, including `converge.yml`, `create.yml`, `destroy.yml`, `molecule.yml`, and a `callback_plugins/profile_tasks.py` for task timing
- Molecule verification - `molecule/default/verify.yml` asserts gcc/build-essential/python3-dev presence, verifies all tool binaries, checks impacket venv regsecrets module availability, enforces bash-wrapper shebangs on ntlmrelayx.py and petitpotam (non-Kali), validates Kali petitpotam as a symlink, and runs `--help` smoke tests on 11 impacket entrypoints plus all coercion tools
- Role documentation - `roles/coercion_tools/README.md` with full variable reference table, per-task-file breakdowns, example playbook, and platform support matrix

**Changed:**

- CI test matrix - Added `{"name":"Role Test - coercion_tools","path":"roles/coercion_tools"}` to the full-test `MATRIX_JSON` in `.github/workflows/molecule.yaml`
- README collection diagram and role table - Added `coercion_tools` node to the Mermaid graph and a corresponding entry in the roles reference table linking to the new README