### PR TITLE
fix: add download retry logic and fix mise dependency conflicts

### DIFF
--- a/roles/privesc_tools/README.md
+++ b/roles/privesc_tools/README.md
@@ -15,6 +15,8 @@ Install and configure privilege escalation tools
 
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
+| `privesc_tools_download_retries` | int | <code>5</code> | No description |
+| `privesc_tools_download_delay` | int | <code>15</code> | No description |
 | `privesc_tools_kali_packages` | list | <code>&#91;&#93;</code> | No description |
 | `privesc_tools_kali_packages.0` | str | <code>git</code> | No description |
 | `privesc_tools_kali_packages.1` | str | <code>python3-dev</code> | No description |

--- a/roles/privesc_tools/defaults/main.yml
+++ b/roles/privesc_tools/defaults/main.yml
@@ -2,6 +2,12 @@
 # Privilege escalation tools for Windows targets
 # These tools exploit various Windows privilege escalation vectors
 
+# Retry behavior for downloads from GitHub. Raw/release endpoints
+# occasionally return HTTP 429 (Too Many Requests) when several molecule
+# containers pull binaries at once, so downloads are retried with a delay.
+privesc_tools_download_retries: 5
+privesc_tools_download_delay: 15
+
 # Privesc tool packages (Kali-specific)
 privesc_tools_kali_packages:
   - git

--- a/roles/privesc_tools/tasks/linux.yml
+++ b/roles/privesc_tools/tasks/linux.yml
@@ -96,6 +96,10 @@
     dest: "{{ privesc_tools_printspoofer_install_dir }}/PrintSpoofer64.exe"
     mode: '0755'
   become: true
+  register: privesc_tools_printspoofer_download
+  until: privesc_tools_printspoofer_download is succeeded
+  retries: "{{ privesc_tools_download_retries }}"
+  delay: "{{ privesc_tools_download_delay }}"
   when: privesc_tools_install_printspoofer
 
 - name: Create GodPotato directory
@@ -112,6 +116,10 @@
     dest: "{{ privesc_tools_godpotato_install_dir }}/GodPotato-NET4.exe"
     mode: '0755'
   become: true
+  register: privesc_tools_godpotato_download
+  until: privesc_tools_godpotato_download is succeeded
+  retries: "{{ privesc_tools_download_retries }}"
+  delay: "{{ privesc_tools_download_delay }}"
   when: privesc_tools_install_godpotato
 
 - name: Clone SweetPotato from GitHub
@@ -137,6 +145,10 @@
     dest: "{{ privesc_tools_krbrelayup_install_dir }}/KrbRelayUp.exe"
     mode: '0755'
   become: true
+  register: privesc_tools_krbrelayup_download
+  until: privesc_tools_krbrelayup_download is succeeded
+  retries: "{{ privesc_tools_download_retries }}"
+  delay: "{{ privesc_tools_download_delay }}"
   when: privesc_tools_install_krbrelayup
 
 - name: Install mono-runtime to execute KrbRelayUp.exe on Linux
@@ -186,6 +198,10 @@
     dest: "{{ privesc_tools_seatbelt_install_dir }}/Seatbelt.exe"
     mode: '0755'
   become: true
+  register: privesc_tools_seatbelt_download
+  until: privesc_tools_seatbelt_download is succeeded
+  retries: "{{ privesc_tools_download_retries }}"
+  delay: "{{ privesc_tools_download_delay }}"
   when: privesc_tools_install_seatbelt
 
 - name: Create SharpUp directory
@@ -202,6 +218,10 @@
     dest: "{{ privesc_tools_sharpup_install_dir }}/SharpUp.exe"
     mode: '0755'
   become: true
+  register: privesc_tools_sharpup_download
+  until: privesc_tools_sharpup_download is succeeded
+  retries: "{{ privesc_tools_download_retries }}"
+  delay: "{{ privesc_tools_download_delay }}"
   when: privesc_tools_install_sharpup
 
 - name: Create PowerUp directory
@@ -218,6 +238,10 @@
     dest: "{{ privesc_tools_powerup_install_dir }}/PowerUp.ps1"
     mode: '0755'
   become: true
+  register: privesc_tools_powerup_download
+  until: privesc_tools_powerup_download is succeeded
+  retries: "{{ privesc_tools_download_retries }}"
+  delay: "{{ privesc_tools_download_delay }}"
   when: privesc_tools_install_powerup
 
 - name: Create PowerUpSQL directory
@@ -234,6 +258,10 @@
     dest: "{{ privesc_tools_powerupsql_install_dir }}/PowerUpSQL.ps1"
     mode: '0755'
   become: true
+  register: privesc_tools_powerupsql_download
+  until: privesc_tools_powerupsql_download is succeeded
+  retries: "{{ privesc_tools_download_retries }}"
+  delay: "{{ privesc_tools_download_delay }}"
   when: privesc_tools_install_powerupsql
 
 - name: Create WinPEAS directory
@@ -250,6 +278,10 @@
     dest: "{{ privesc_tools_winpeas_install_dir }}/winPEASany_ofs.exe"
     mode: '0755'
   become: true
+  register: privesc_tools_winpeas_download
+  until: privesc_tools_winpeas_download is succeeded
+  retries: "{{ privesc_tools_download_retries }}"
+  delay: "{{ privesc_tools_download_delay }}"
   when: privesc_tools_install_winpeas
 
 - name: Create LinPEAS directory
@@ -266,6 +298,10 @@
     dest: "{{ privesc_tools_linpeas_install_dir }}/linpeas.sh"
     mode: '0755'
   become: true
+  register: privesc_tools_linpeas_download
+  until: privesc_tools_linpeas_download is succeeded
+  retries: "{{ privesc_tools_download_retries }}"
+  delay: "{{ privesc_tools_download_delay }}"
   when: privesc_tools_install_linpeas
 
 - name: Create RunasCs directory
@@ -282,6 +318,10 @@
     dest: "/tmp/RunasCs.zip"
     mode: '0644'
   become: true
+  register: privesc_tools_runascs_download
+  until: privesc_tools_runascs_download is succeeded
+  retries: "{{ privesc_tools_download_retries }}"
+  delay: "{{ privesc_tools_download_delay }}"
   when: privesc_tools_install_runascs
 
 - name: Extract RunasCs

--- a/roles/sliver/README.md
+++ b/roles/sliver/README.md
@@ -13,7 +13,6 @@ Install sliver c2
 
 
 - cowdogmoo.workstation.package_management
-- cowdogmoo.workstation.mise
 
 ## Role Variables
 

--- a/roles/sliver/meta/main.yml
+++ b/roles/sliver/meta/main.yml
@@ -20,6 +20,11 @@ galaxy_info:
   galaxy_tags:
     - c2
     - offsec
+# Note: cowdogmoo.workstation.mise is intentionally NOT a meta dependency.
+# This role installs mise itself (see tasks/main.yml) for the sliver user
+# with the sliver-specific plugin set. Declaring mise here would run it a
+# second time with role defaults (root user, full default plugin list), and
+# the two invocations clobber shared state (/usr/local/bin ownership and
+# /tmp/install_mise_plugins), which breaks the molecule idempotence test.
 dependencies:
   - role: cowdogmoo.workstation.package_management
-  - role: cowdogmoo.workstation.mise

--- a/roles/ttpforge/README.md
+++ b/roles/ttpforge/README.md
@@ -15,7 +15,6 @@ attacker Tactics, Techniques, and Procedures (TTPs)
 
 
 - cowdogmoo.workstation.package_management
-- cowdogmoo.workstation.mise
 
 ## Role Variables
 

--- a/roles/ttpforge/meta/main.yml
+++ b/roles/ttpforge/meta/main.yml
@@ -24,6 +24,11 @@ galaxy_info:
     - ttpforge
     - offsec
 
+# Note: cowdogmoo.workstation.mise is intentionally NOT a meta dependency.
+# This role installs mise itself (see tasks/main.yml) for the ttpforge user
+# with the ttpforge-specific plugin set. Declaring mise here would run it a
+# second time with role defaults (root user, full default plugin list), and
+# the two invocations clobber shared state (/usr/local/bin ownership and
+# /tmp/install_mise_plugins), which breaks the molecule idempotence test.
 dependencies:
   - role: cowdogmoo.workstation.package_management
-  - role: cowdogmoo.workstation.mise


### PR DESCRIPTION
**Key Changes:**

- Added configurable retry/delay behavior for all GitHub binary downloads in the `privesc_tools` role to handle HTTP 429 rate limiting during parallel molecule test runs
- Removed `cowdogmoo.workstation.mise` as a meta dependency from both `sliver` and `ttpforge` roles to prevent shared-state conflicts that broke molecule idempotence tests
- Documented the intentional omission of the mise meta dependency with inline comments explaining the rationale

**Added:**

- Download retry configuration - Introduced `privesc_tools_download_retries` (default: 5) and `privesc_tools_download_delay` (default: 15) variables in `defaults/main.yml` and documented them in `README.md` for the `privesc_tools` role
- Retry logic on all binary downloads - Applied `register`, `until`, `retries`, and `delay` directives to all nine GitHub download tasks (PrintSpoofer, GodPotato, KrbRelayUp, Seatbelt, SharpUp, PowerUp, PowerUpSQL, WinPEAS, LinPEAS, RunasCs) in `roles/privesc_tools/tasks/linux.yml`

**Changed:**

- Mise dependency handling in `sliver` and `ttpforge` roles - Removed `cowdogmoo.workstation.mise` from `meta/main.yml` dependencies in both roles; added explanatory comments clarifying that each role manages its own mise installation for a specific user and plugin set, and that the duplicate invocation was clobbering `/usr/local/bin` ownership and `/tmp/install_mise_plugins` shared state