### PR TITLE
ci: add retry logic for pre-commit task execution

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -67,4 +67,13 @@ jobs:
 
       - name: Run pre-commit
         run: |
-          task -y run-pre-commit
+          # Retry to survive transient failures fetching remote Taskfiles from raw.githubusercontent.com.
+          for attempt in 1 2 3; do
+            if task -y run-pre-commit; then
+              exit 0
+            fi
+            echo "Attempt ${attempt} failed; retrying in $((attempt * 10))s..."
+            sleep $((attempt * 10))
+          done
+          echo "All retries exhausted"
+          exit 1


### PR DESCRIPTION
**Key Changes:**

- Wrapped `task -y run-pre-commit` in a retry loop to handle transient network failures when fetching remote Taskfiles from `raw.githubusercontent.com`
- Implements exponential backoff with up to 3 attempts before failing the workflow

**Changed:**

- Pre-commit execution step - Replaced the single `task -y run-pre-commit` call with a retry loop that attempts up to 3 times, sleeping 10s, 20s, and 30s between attempts respectively, then exits with a failure if all retries are exhausted