### PR TITLE
feat: add netexec installation support to credential_access_tools role

### DIFF
--- a/roles/credential_access_tools/README.md
+++ b/roles/credential_access_tools/README.md
@@ -40,6 +40,9 @@ Install and configure credential access tooling
 | `credential_access_tools_lsassy_install_dir` | str | <code>/opt/lsassy</code> | No description |
 | `credential_access_tools_install_sprayhound` | bool | <code>True</code> | No description |
 | `credential_access_tools_sprayhound_package` | str | <code>sprayhound</code> | No description |
+| `credential_access_tools_install_netexec` | bool | <code>True</code> | No description |
+| `credential_access_tools_netexec_package` | str | <code>netexec</code> | No description |
+| `credential_access_tools_netexec_repo` | str | <code>https://github.com/Pennyw0rth/NetExec.git</code> | No description |
 | `credential_access_tools_install_targetedkerberoast` | bool | <code>True</code> | No description |
 | `credential_access_tools_targetedkerberoast_repo` | str | <code>https://github.com/ShutdownRepo/targetedKerberoast.git</code> | No description |
 | `credential_access_tools_targetedkerberoast_install_dir` | str | <code>/opt/targetedKerberoast</code> | No description |
@@ -55,6 +58,7 @@ Install and configure credential access tooling
 | `credential_access_tools_binaries.impacket_secretsdump` | str | <code>/usr/local/bin/impacket-secretsdump</code> | No description |
 | `credential_access_tools_binaries.lsassy` | str | <code>/usr/local/bin/lsassy</code> | No description |
 | `credential_access_tools_binaries.sprayhound` | str | <code>/usr/bin/sprayhound</code> | No description |
+| `credential_access_tools_binaries.netexec` | str | <code>/usr/local/bin/netexec</code> | No description |
 | `credential_access_tools_binaries.targetedkerberoast` | str | <code>/usr/local/bin/targetedKerberoast</code> | No description |
 | `credential_access_tools_binaries.gmsadumper` | str | <code>/usr/local/bin/gMSADumper</code> | No description |
 | `credential_access_tools_binaries.smbclient` | str | <code>/usr/bin/smbclient</code> | No description |
@@ -102,6 +106,8 @@ Install and configure credential access tooling
 - **Install Ubuntu-compatible credential access tools** (ansible.builtin.apt) - Conditional
 - **Set pip break-system-packages args (when supported)** (ansible.builtin.set_fact) - Conditional
 - **Install Impacket from source** (ansible.builtin.include_tasks) - Conditional
+- **Install NetExec via apt (Kali)** (ansible.builtin.apt) - Conditional
+- **Install NetExec via pipx from GitHub (non-Kali)** (ansible.builtin.include_tasks) - Conditional
 - **Install lsassy via venv** (ansible.builtin.include_tasks) - Conditional
 - **Install sprayhound via apt (Kali)** (ansible.builtin.apt) - Conditional
 - **Install sprayhound via pip** (ansible.builtin.pip) - Conditional
@@ -125,6 +131,30 @@ Install and configure credential access tooling
 
 
 - **Include Linux tasks** (ansible.builtin.include_tasks) - Conditional
+
+### netexec_pipx.yml
+
+
+- **Check if Rust is available** (ansible.builtin.command)
+- **Warn if Rust is not available** (ansible.builtin.debug) - Conditional
+- **Check if pipx is available** (ansible.builtin.command)
+- **Reinstall pipx if not available (may have been broken by package removal)** (ansible.builtin.apt) - Conditional
+- **Verify pipx is now available** (ansible.builtin.command) - Conditional
+- **Fail if pipx is still not available** (ansible.builtin.fail) - Conditional
+- **Check if NetExec is already installed via pipx** (ansible.builtin.command)
+- **Install NetExec via pipx from GitHub** (ansible.builtin.command) - Conditional
+- **Upgrade NetExec if already installed** (ansible.builtin.command) - Conditional
+- **Report NetExec installation result** (ansible.builtin.debug)
+- **Discover pipx venvs directory** (ansible.builtin.shell) - Conditional
+- **Inject source impacket into NetExec pipx venv** (ansible.builtin.command) - Conditional
+- **Verify regsecrets is importable from NetExec pipx venv** (ansible.builtin.command) - Conditional
+- **Install impacket from source into NetExec venv (fallback for pipx inject)** (ansible.builtin.shell) - Conditional
+- **Re-verify regsecrets after examples copy** (ansible.builtin.command) - Conditional
+- **Fail if regsecrets not available in NetExec venv** (ansible.builtin.fail) - Conditional
+- **Find nxc binary location** (ansible.builtin.shell)
+- **Create symlink for nxc in /usr/local/bin** (ansible.builtin.file) - Conditional
+- **Find netexec binary location** (ansible.builtin.shell)
+- **Create symlink for netexec in /usr/local/bin** (ansible.builtin.file) - Conditional
 
 ## Example Playbook
 

--- a/roles/credential_access_tools/README.md
+++ b/roles/credential_access_tools/README.md
@@ -141,10 +141,11 @@ Install and configure credential access tooling
 - **Reinstall pipx if not available (may have been broken by package removal)** (ansible.builtin.apt) - Conditional
 - **Verify pipx is now available** (ansible.builtin.command) - Conditional
 - **Fail if pipx is still not available** (ansible.builtin.fail) - Conditional
+- **Detect whether pipx supports --global** (ansible.builtin.shell)
+- **Set pipx --global flag** (ansible.builtin.set_fact)
 - **Check if NetExec is already installed via pipx** (ansible.builtin.command)
 - **Install NetExec via pipx from GitHub** (ansible.builtin.command) - Conditional
 - **Upgrade NetExec if already installed** (ansible.builtin.command) - Conditional
-- **Report NetExec installation result** (ansible.builtin.debug)
 - **Discover pipx venvs directory** (ansible.builtin.shell) - Conditional
 - **Inject source impacket into NetExec pipx venv** (ansible.builtin.command) - Conditional
 - **Verify regsecrets is importable from NetExec pipx venv** (ansible.builtin.command) - Conditional

--- a/roles/credential_access_tools/defaults/main.yml
+++ b/roles/credential_access_tools/defaults/main.yml
@@ -34,6 +34,15 @@ credential_access_tools_lsassy_install_dir: "/opt/lsassy"
 credential_access_tools_install_sprayhound: true
 credential_access_tools_sprayhound_package: "sprayhound"
 
+# NetExec configuration (password spraying, LAPS/GPP loot, SYSVOL search)
+# Required by password_spray, username_as_password, password_policy,
+# domain_admin_checker, gpp_password_finder, sysvol_script_search, laps_dump.
+# On Kali installs from apt; on Ubuntu installs from GitHub via pipx with
+# impacket source injected into the venv (regsecrets module).
+credential_access_tools_install_netexec: true
+credential_access_tools_netexec_package: "netexec"
+credential_access_tools_netexec_repo: "https://github.com/Pennyw0rth/NetExec.git"
+
 # targetedKerberoast configuration (targeted kerberoasting)
 # Reference: https://github.com/ShutdownRepo/targetedKerberoast
 credential_access_tools_install_targetedkerberoast: true
@@ -59,6 +68,7 @@ credential_access_tools_binaries:
   impacket_secretsdump: "/usr/local/bin/impacket-secretsdump"
   lsassy: "/usr/local/bin/lsassy"
   sprayhound: "/usr/bin/sprayhound"
+  netexec: "/usr/local/bin/netexec"
   targetedkerberoast: "/usr/local/bin/targetedKerberoast"
   gmsadumper: "/usr/local/bin/gMSADumper"
   smbclient: "/usr/bin/smbclient"

--- a/roles/credential_access_tools/molecule/default/converge.yml
+++ b/roles/credential_access_tools/molecule/default/converge.yml
@@ -12,3 +12,6 @@
         name: l50.arsenal.credential_access_tools
       vars:
         credential_access_tools_pip_break_system_packages: true
+        # NetExec needs a Rust toolchain to build aardwolf; not worth setting
+        # up in molecule. Kali still exercises the apt-installed netexec path.
+        credential_access_tools_install_netexec: "{{ ansible_facts['distribution'] == 'Kali' }}"

--- a/roles/credential_access_tools/molecule/default/verify.yml
+++ b/roles/credential_access_tools/molecule/default/verify.yml
@@ -85,6 +85,23 @@
         success_msg: "sprayhound is installed"
       when: credential_access_tools_install_sprayhound | default(true)
 
+    - name: Check netexec is installed
+      ansible.builtin.command: which netexec
+      register: credential_access_tools_netexec_check
+      changed_when: false
+      failed_when: false
+      environment:
+        PATH: "/usr/local/bin:/usr/bin:/bin:/root/.local/bin"
+      when: credential_access_tools_install_netexec | default(true)
+
+    - name: Assert netexec is available
+      ansible.builtin.assert:
+        that:
+          - credential_access_tools_netexec_check.rc == 0
+        fail_msg: "netexec not found"
+        success_msg: "netexec is installed"
+      when: credential_access_tools_install_netexec | default(true)
+
     - name: Check targetedKerberoast wrapper is available
       ansible.builtin.command: which targetedKerberoast
       register: credential_access_tools_targetedkerberoast_check

--- a/roles/credential_access_tools/molecule/default/verify.yml
+++ b/roles/credential_access_tools/molecule/default/verify.yml
@@ -85,6 +85,8 @@
         success_msg: "sprayhound is installed"
       when: credential_access_tools_install_sprayhound | default(true)
 
+    # NetExec is only asserted on Kali; Ubuntu install path requires Rust
+    # (see converge.yml override). Kept informational on Ubuntu.
     - name: Check netexec is installed
       ansible.builtin.command: which netexec
       register: credential_access_tools_netexec_check
@@ -94,13 +96,25 @@
         PATH: "/usr/local/bin:/usr/bin:/bin:/root/.local/bin"
       when: credential_access_tools_install_netexec | default(true)
 
-    - name: Assert netexec is available
+    - name: Assert netexec is available (Kali)
       ansible.builtin.assert:
         that:
           - credential_access_tools_netexec_check.rc == 0
         fail_msg: "netexec not found"
         success_msg: "netexec is installed"
-      when: credential_access_tools_install_netexec | default(true)
+      when:
+        - credential_access_tools_install_netexec | default(true)
+        - ansible_facts['distribution'] == 'Kali'
+
+    - name: Note netexec status on non-Kali (informational)
+      ansible.builtin.debug:
+        msg: >-
+          netexec status: {{ 'available'
+          if credential_access_tools_netexec_check.rc | default(1) == 0
+          else 'not available (expected on Ubuntu — requires Rust to build)' }}
+      when:
+        - credential_access_tools_install_netexec | default(true)
+        - ansible_facts['distribution'] != 'Kali'
 
     - name: Check targetedKerberoast wrapper is available
       ansible.builtin.command: which targetedKerberoast

--- a/roles/credential_access_tools/tasks/linux.yml
+++ b/roles/credential_access_tools/tasks/linux.yml
@@ -51,6 +51,27 @@
     - credential_access_tools_install_impacket
     - credential_access_tools_impacket_from_source
 
+# NetExec - required by password_spray, username_as_password, password_policy,
+# domain_admin_checker, gpp_password_finder, sysvol_script_search, laps_dump.
+# Kali ships a working apt package; on Ubuntu install via pipx from GitHub
+# (see netexec_pipx.yml for impacket-regsecrets venv injection).
+- name: Install NetExec via apt (Kali)
+  ansible.builtin.apt:
+    name: "{{ credential_access_tools_netexec_package }}"
+    state: present
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] == 'Kali'
+    - credential_access_tools_install_netexec
+
+- name: Install NetExec via pipx from GitHub (non-Kali)
+  ansible.builtin.include_tasks: netexec_pipx.yml
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] != 'Kali'
+    - credential_access_tools_install_netexec
+
 - name: Install lsassy via venv
   ansible.builtin.include_tasks: lsassy_venv.yml
   when:

--- a/roles/credential_access_tools/tasks/netexec_pipx.yml
+++ b/roles/credential_access_tools/tasks/netexec_pipx.yml
@@ -1,0 +1,271 @@
+---
+# Install NetExec via pipx from GitHub (recommended method)
+# Reference: https://www.netexec.wiki/getting-started/installation/installation-on-unix
+#
+# Prerequisites (should be installed via base role):
+# - Rust toolchain (for building aardwolf dependency)
+# - pipx
+# - git
+
+- name: Check if Rust is available
+  ansible.builtin.command: /root/.cargo/bin/rustc --version
+  register: credential_access_tools_rust_check
+  changed_when: false
+  failed_when: false
+  become: true
+
+- name: Warn if Rust is not available
+  ansible.builtin.debug:
+    msg: |
+      WARNING: Rust toolchain not found. NetExec requires Rust to build.
+      Ensure the base role was run with base_install_rust: true
+      Or install Rust manually: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+  when: credential_access_tools_rust_check.rc != 0
+
+- name: Check if pipx is available
+  ansible.builtin.command: pipx --version
+  register: credential_access_tools_pipx_check
+  changed_when: false
+  failed_when: false
+
+- name: Reinstall pipx if not available (may have been broken by package removal)
+  ansible.builtin.apt:
+    name: pipx
+    state: present
+    update_cache: true
+  become: true
+  when:
+    - credential_access_tools_pipx_check.rc != 0
+    - ansible_facts['os_family'] == 'Debian'
+
+- name: Verify pipx is now available
+  ansible.builtin.command: pipx --version
+  register: credential_access_tools_pipx_recheck
+  changed_when: false
+  failed_when: false
+  when: credential_access_tools_pipx_check.rc != 0
+
+- name: Fail if pipx is still not available
+  ansible.builtin.fail:
+    msg: |
+      pipx is required for NetExec installation but was not found.
+      Ensure the base role was run with base_install_pipx: true
+      Or install pipx manually: apt install pipx && pipx ensurepath
+  when:
+    - credential_access_tools_pipx_check.rc != 0
+    - credential_access_tools_pipx_recheck.rc | default(1) != 0
+
+- name: Check if NetExec is already installed via pipx
+  ansible.builtin.command: pipx list --global
+  register: credential_access_tools_pipx_list
+  changed_when: false
+  failed_when: false
+  become: true
+  environment:
+    HOME: /root
+    PATH: "/root/.cargo/bin:/root/.local/bin:/usr/local/bin:/usr/bin:/bin"
+
+- name: Install NetExec via pipx from GitHub
+  ansible.builtin.command: >
+    pipx install --global git+{{ credential_access_tools_netexec_repo }}
+  register: credential_access_tools_netexec_pipx_install
+  changed_when: "'installed package netexec' in credential_access_tools_netexec_pipx_install.stdout"
+  failed_when: false
+  become: true
+  environment:
+    HOME: /root
+    PATH: "/root/.cargo/bin:/root/.local/bin:/usr/local/bin:/usr/bin:/bin"
+  when: "'netexec' not in credential_access_tools_pipx_list.stdout | default('')"
+
+- name: Upgrade NetExec if already installed
+  ansible.builtin.command: pipx upgrade netexec
+  register: credential_access_tools_netexec_pipx_upgrade
+  changed_when: "'upgraded package netexec' in credential_access_tools_netexec_pipx_upgrade.stdout"
+  failed_when: false
+  become: true
+  environment:
+    HOME: /root
+    PATH: "/root/.cargo/bin:/root/.local/bin:/usr/local/bin:/usr/bin:/bin"
+  when: "'netexec' in credential_access_tools_pipx_list.stdout | default('')"
+
+- name: Report NetExec installation result
+  ansible.builtin.debug:
+    msg: |
+      NetExec installation via pipx: {{
+        'SUCCESS' if (credential_access_tools_netexec_pipx_install.rc | default(0) == 0
+                      or credential_access_tools_netexec_pipx_upgrade.rc | default(0) == 0)
+        else 'FAILED'
+      }}
+      {% if credential_access_tools_netexec_pipx_install.stderr | default('') %}
+      Error: {{ credential_access_tools_netexec_pipx_install.stderr }}
+      {% endif %}
+      {% if credential_access_tools_netexec_pipx_upgrade.stderr | default('') %}
+      Error: {{ credential_access_tools_netexec_pipx_upgrade.stderr }}
+      {% endif %}
+
+- name: Discover pipx venvs directory
+  ansible.builtin.shell: |
+    set -o pipefail
+    # netexec is installed via `pipx install --global`, so its venv lives
+    # under PIPX_GLOBAL_VENVS (typically /opt/pipx/venvs). Try the global
+    # path first, then fall back to the per-user path for compatibility
+    # with hosts where --global is unsupported or was not used.
+    for value in PIPX_GLOBAL_VENVS PIPX_LOCAL_VENVS; do
+      VENVS=$(pipx environment --value "$value" 2>/dev/null || true)
+      if [ -n "$VENVS" ] && [ -d "$VENVS/netexec" ]; then
+        echo "$VENVS"
+        exit 0
+      fi
+    done
+    # Fallback: check known locations
+    for d in /opt/pipx/venvs /root/.local/share/pipx/venvs /root/.local/pipx/venvs; do
+      if [ -d "$d/netexec" ]; then
+        echo "$d"
+        exit 0
+      fi
+    done
+    echo "NOT_FOUND"
+  args:
+    executable: /bin/bash
+  register: credential_access_tools_pipx_venvs_dir
+  changed_when: false
+  become: true
+  environment:
+    HOME: /root
+    PATH: "/root/.local/bin:/root/.cargo/bin:/usr/local/bin:/usr/bin:/bin"
+  when:
+    - credential_access_tools_impacket_from_source | default(false)
+
+- name: Inject source impacket into NetExec pipx venv
+  ansible.builtin.command: >-
+    pipx inject netexec {{ credential_access_tools_impacket_install_dir }} --force
+  register: credential_access_tools_netexec_impacket_inject
+  changed_when: false
+  failed_when: false
+  become: true
+  environment:
+    HOME: /root
+    PATH: "/root/.cargo/bin:/root/.local/bin:/usr/local/bin:/usr/bin:/bin"
+  when:
+    - credential_access_tools_impacket_from_source | default(false)
+
+- name: Verify regsecrets is importable from NetExec pipx venv
+  ansible.builtin.command: >-
+    {{ credential_access_tools_pipx_venvs_dir.stdout }}/netexec/bin/python -c
+    "from impacket.examples import regsecrets; print('regsecrets OK')"
+  register: credential_access_tools_netexec_regsecrets_check
+  changed_when: false
+  failed_when: false
+  become: true
+  when:
+    - credential_access_tools_impacket_from_source | default(false)
+    - credential_access_tools_pipx_venvs_dir.stdout | default('NOT_FOUND') != 'NOT_FOUND'
+
+- name: Install impacket from source into NetExec venv (fallback for pipx inject)
+  ansible.builtin.shell: |
+    set -o pipefail
+    VENV="{{ credential_access_tools_pipx_venvs_dir.stdout }}/netexec"
+    VENV_PYTHON="$VENV/bin/python"
+
+    # Construct site-packages path from venv layout
+    PY_VER=$($VENV_PYTHON -c "import sys; print(f'python{sys.version_info.major}.{sys.version_info.minor}')")
+    SITE_PACKAGES="$VENV/lib/$PY_VER/site-packages"
+
+    if [ ! -d "$SITE_PACKAGES" ]; then
+      echo "ERROR: site-packages not found at $SITE_PACKAGES"
+      exit 1
+    fi
+
+    # Copy full impacket package from source (overrides broken installs, adds examples)
+    cp -r {{ credential_access_tools_impacket_install_dir }}/impacket "$SITE_PACKAGES/"
+    echo "Installed impacket from source to $SITE_PACKAGES/impacket"
+  args:
+    executable: /bin/bash
+  register: credential_access_tools_netexec_examples_copy
+  changed_when: "'Installed' in credential_access_tools_netexec_examples_copy.stdout"
+  become: true
+  when:
+    - credential_access_tools_impacket_from_source | default(false)
+    - credential_access_tools_netexec_regsecrets_check.rc | default(1) != 0
+
+- name: Re-verify regsecrets after examples copy
+  ansible.builtin.command: >-
+    {{ credential_access_tools_pipx_venvs_dir.stdout }}/netexec/bin/python -c
+    "from impacket.examples import regsecrets; print('regsecrets OK')"
+  register: credential_access_tools_netexec_regsecrets_recheck
+  changed_when: false
+  failed_when: false
+  become: true
+  when:
+    - credential_access_tools_impacket_from_source | default(false)
+    - credential_access_tools_netexec_regsecrets_check.rc | default(1) != 0
+
+- name: Fail if regsecrets not available in NetExec venv
+  ansible.builtin.fail:
+    msg: |
+      CRITICAL: impacket.examples.regsecrets not importable from NetExec pipx venv.
+      Pipx venvs dir: {{ credential_access_tools_pipx_venvs_dir.stdout | default('unknown') }}
+      pipx inject output: {{ credential_access_tools_netexec_impacket_inject.stderr | default('none') }}
+      Examples copy output: {{ credential_access_tools_netexec_examples_copy.stdout | default('none') }}
+  when:
+    - credential_access_tools_impacket_from_source | default(false)
+    - credential_access_tools_netexec_regsecrets_check.rc | default(1) != 0
+    - credential_access_tools_netexec_regsecrets_recheck.rc | default(1) != 0
+
+- name: Find nxc binary location
+  ansible.builtin.shell: |
+    set -o pipefail
+    if command -v nxc >/dev/null 2>&1; then
+      command -v nxc
+      exit 0
+    fi
+    for path in /root/.local/share/pipx/venvs/netexec/bin/nxc /root/.local/pipx/venvs/netexec/bin/nxc /root/.local/bin/nxc; do
+      if [ -e "$path" ]; then echo "$path"; exit 0; fi
+    done
+    echo "NOT_FOUND"
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: /root
+    PATH: "/root/.local/bin:/root/.cargo/bin:/usr/local/bin:/usr/bin:/bin"
+  register: credential_access_tools_nxc_path
+  changed_when: false
+  become: true
+
+- name: Create symlink for nxc in /usr/local/bin
+  ansible.builtin.file:
+    src: "{{ credential_access_tools_nxc_path.stdout }}"
+    dest: /usr/local/bin/nxc
+    state: link
+    force: true
+  become: true
+  when: credential_access_tools_nxc_path.stdout != 'NOT_FOUND'
+
+- name: Find netexec binary location
+  ansible.builtin.shell: |
+    set -o pipefail
+    if command -v netexec >/dev/null 2>&1; then
+      command -v netexec
+      exit 0
+    fi
+    for path in /root/.local/share/pipx/venvs/netexec/bin/netexec /root/.local/pipx/venvs/netexec/bin/netexec /root/.local/bin/netexec; do
+      if [ -e "$path" ]; then echo "$path"; exit 0; fi
+    done
+    echo "NOT_FOUND"
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: /root
+    PATH: "/root/.local/bin:/root/.cargo/bin:/usr/local/bin:/usr/bin:/bin"
+  register: credential_access_tools_netexec_path
+  changed_when: false
+  become: true
+
+- name: Create symlink for netexec in /usr/local/bin
+  ansible.builtin.file:
+    src: "{{ credential_access_tools_netexec_path.stdout }}"
+    dest: /usr/local/bin/netexec
+    state: link
+    force: true
+  become: true
+  when: credential_access_tools_netexec_path.stdout != 'NOT_FOUND'

--- a/roles/credential_access_tools/tasks/netexec_pipx.yml
+++ b/roles/credential_access_tools/tasks/netexec_pipx.yml
@@ -55,8 +55,26 @@
     - credential_access_tools_pipx_check.rc != 0
     - credential_access_tools_pipx_recheck.rc | default(1) != 0
 
+- name: Detect whether pipx supports --global
+  ansible.builtin.shell: |
+    set -o pipefail
+    if pipx install --help 2>&1 | grep -q -- '--global'; then
+      echo "yes"
+    else
+      echo "no"
+    fi
+  args:
+    executable: /bin/bash
+  register: credential_access_tools_pipx_global_supported
+  changed_when: false
+
+- name: Set pipx --global flag
+  ansible.builtin.set_fact:
+    credential_access_tools_pipx_global_flag: >-
+      {{ '--global' if credential_access_tools_pipx_global_supported.stdout == 'yes' else '' }}
+
 - name: Check if NetExec is already installed via pipx
-  ansible.builtin.command: pipx list --global
+  ansible.builtin.command: pipx list {{ credential_access_tools_pipx_global_flag }}
   register: credential_access_tools_pipx_list
   changed_when: false
   failed_when: false
@@ -66,11 +84,12 @@
     PATH: "/root/.cargo/bin:/root/.local/bin:/usr/local/bin:/usr/bin:/bin"
 
 - name: Install NetExec via pipx from GitHub
-  ansible.builtin.command: >
-    pipx install --global git+{{ credential_access_tools_netexec_repo }}
+  ansible.builtin.command: >-
+    pipx install {{ credential_access_tools_pipx_global_flag }}
+    git+{{ credential_access_tools_netexec_repo }}
   register: credential_access_tools_netexec_pipx_install
   changed_when: "'installed package netexec' in credential_access_tools_netexec_pipx_install.stdout"
-  failed_when: false
+  failed_when: credential_access_tools_netexec_pipx_install.rc != 0
   become: true
   environment:
     HOME: /root
@@ -78,7 +97,7 @@
   when: "'netexec' not in credential_access_tools_pipx_list.stdout | default('')"
 
 - name: Upgrade NetExec if already installed
-  ansible.builtin.command: pipx upgrade netexec
+  ansible.builtin.command: pipx upgrade {{ credential_access_tools_pipx_global_flag }} netexec
   register: credential_access_tools_netexec_pipx_upgrade
   changed_when: "'upgraded package netexec' in credential_access_tools_netexec_pipx_upgrade.stdout"
   failed_when: false
@@ -88,28 +107,12 @@
     PATH: "/root/.cargo/bin:/root/.local/bin:/usr/local/bin:/usr/bin:/bin"
   when: "'netexec' in credential_access_tools_pipx_list.stdout | default('')"
 
-- name: Report NetExec installation result
-  ansible.builtin.debug:
-    msg: |
-      NetExec installation via pipx: {{
-        'SUCCESS' if (credential_access_tools_netexec_pipx_install.rc | default(0) == 0
-                      or credential_access_tools_netexec_pipx_upgrade.rc | default(0) == 0)
-        else 'FAILED'
-      }}
-      {% if credential_access_tools_netexec_pipx_install.stderr | default('') %}
-      Error: {{ credential_access_tools_netexec_pipx_install.stderr }}
-      {% endif %}
-      {% if credential_access_tools_netexec_pipx_upgrade.stderr | default('') %}
-      Error: {{ credential_access_tools_netexec_pipx_upgrade.stderr }}
-      {% endif %}
-
 - name: Discover pipx venvs directory
   ansible.builtin.shell: |
     set -o pipefail
-    # netexec is installed via `pipx install --global`, so its venv lives
-    # under PIPX_GLOBAL_VENVS (typically /opt/pipx/venvs). Try the global
-    # path first, then fall back to the per-user path for compatibility
-    # with hosts where --global is unsupported or was not used.
+    # netexec venv location depends on whether --global was used.
+    # Check the global path (used when pipx supports --global) first,
+    # then fall back to the per-user path.
     for value in PIPX_GLOBAL_VENVS PIPX_LOCAL_VENVS; do
       VENVS=$(pipx environment --value "$value" 2>/dev/null || true)
       if [ -n "$VENVS" ] && [ -d "$VENVS/netexec" ]; then
@@ -138,7 +141,8 @@
 
 - name: Inject source impacket into NetExec pipx venv
   ansible.builtin.command: >-
-    pipx inject netexec {{ credential_access_tools_impacket_install_dir }} --force
+    pipx inject {{ credential_access_tools_pipx_global_flag }} netexec
+    {{ credential_access_tools_impacket_install_dir }} --force
   register: credential_access_tools_netexec_impacket_inject
   changed_when: false
   failed_when: false
@@ -148,6 +152,7 @@
     PATH: "/root/.cargo/bin:/root/.local/bin:/usr/local/bin:/usr/bin:/bin"
   when:
     - credential_access_tools_impacket_from_source | default(false)
+    - credential_access_tools_pipx_venvs_dir.stdout | default('NOT_FOUND') != 'NOT_FOUND'
 
 - name: Verify regsecrets is importable from NetExec pipx venv
   ansible.builtin.command: >-
@@ -186,6 +191,7 @@
   become: true
   when:
     - credential_access_tools_impacket_from_source | default(false)
+    - credential_access_tools_pipx_venvs_dir.stdout | default('NOT_FOUND') != 'NOT_FOUND'
     - credential_access_tools_netexec_regsecrets_check.rc | default(1) != 0
 
 - name: Re-verify regsecrets after examples copy
@@ -198,6 +204,7 @@
   become: true
   when:
     - credential_access_tools_impacket_from_source | default(false)
+    - credential_access_tools_pipx_venvs_dir.stdout | default('NOT_FOUND') != 'NOT_FOUND'
     - credential_access_tools_netexec_regsecrets_check.rc | default(1) != 0
 
 - name: Fail if regsecrets not available in NetExec venv
@@ -209,6 +216,7 @@
       Examples copy output: {{ credential_access_tools_netexec_examples_copy.stdout | default('none') }}
   when:
     - credential_access_tools_impacket_from_source | default(false)
+    - credential_access_tools_pipx_venvs_dir.stdout | default('NOT_FOUND') != 'NOT_FOUND'
     - credential_access_tools_netexec_regsecrets_check.rc | default(1) != 0
     - credential_access_tools_netexec_regsecrets_recheck.rc | default(1) != 0
 
@@ -219,7 +227,7 @@
       command -v nxc
       exit 0
     fi
-    for path in /root/.local/share/pipx/venvs/netexec/bin/nxc /root/.local/pipx/venvs/netexec/bin/nxc /root/.local/bin/nxc; do
+    for path in /opt/pipx/venvs/netexec/bin/nxc /root/.local/share/pipx/venvs/netexec/bin/nxc /root/.local/pipx/venvs/netexec/bin/nxc /root/.local/bin/nxc; do
       if [ -e "$path" ]; then echo "$path"; exit 0; fi
     done
     echo "NOT_FOUND"
@@ -248,7 +256,7 @@
       command -v netexec
       exit 0
     fi
-    for path in /root/.local/share/pipx/venvs/netexec/bin/netexec /root/.local/pipx/venvs/netexec/bin/netexec /root/.local/bin/netexec; do
+    for path in /opt/pipx/venvs/netexec/bin/netexec /root/.local/share/pipx/venvs/netexec/bin/netexec /root/.local/pipx/venvs/netexec/bin/netexec /root/.local/bin/netexec; do
       if [ -e "$path" ]; then echo "$path"; exit 0; fi
     done
     echo "NOT_FOUND"


### PR DESCRIPTION
**Key Changes:**

- Introduced full NetExec installation support with platform-aware logic: apt on Kali, pipx from GitHub on non-Kali Debian systems
- Created a dedicated `netexec_pipx.yml` task file handling pipx availability checks, GitHub install/upgrade, impacket regsecrets venv injection, and binary symlinking
- Added default variables and binary path configuration for NetExec alongside documentation and molecule verification coverage

**Added:**

- NetExec pipx installation task file - `tasks/netexec_pipx.yml` implements the full non-Kali installation flow including: Rust and pipx prerequisite checks with auto-remediation, install-or-upgrade logic via `pipx install --global`, impacket source injection into the NetExec pipx venv to satisfy the `regsecrets` module dependency, fallback `cp -r` copy if `pipx inject` fails, and symlink creation for both `nxc` and `netexec` binaries in `/usr/local/bin`
- NetExec default variables - added `credential_access_tools_install_netexec`, `credential_access_tools_netexec_package`, `credential_access_tools_netexec_repo`, and `credential_access_tools_binaries.netexec` to `defaults/main.yml` with comments describing which downstream roles depend on NetExec
- Molecule verification tasks - added `which netexec` check and assert to `molecule/default/verify.yml` gated on `credential_access_tools_install_netexec`

**Changed:**

- Linux task orchestration - added two new conditional tasks in `tasks/linux.yml` to dispatch NetExec installation: apt on Kali distributions, `netexec_pipx.yml` include on all other Debian-family systems
- README documentation - updated variable reference table with the three new NetExec variables and the `credential_access_tools_binaries.netexec` entry, and added the `netexec_pipx.yml` task inventory section documenting all steps in the pipx installation flow