### PR TITLE
build: serialize hashcat rust plugin compilation in ansible role

### DIFF
--- a/roles/cracking_tools/README.md
+++ b/roles/cracking_tools/README.md
@@ -75,6 +75,7 @@ Install and configure password cracking tools
 - **Download rustup installer** (ansible.builtin.get_url)
 - **Run rustup installer** (ansible.builtin.shell)
 - **Remove rustup installer** (ansible.builtin.file)
+- **Build hashcat Rust plugins serially** (ansible.builtin.shell)
 - **Build hashcat** (ansible.builtin.shell)
 - **Install hashcat binary** (ansible.builtin.copy)
 - **Create hashcat share directory** (ansible.builtin.file)

--- a/roles/cracking_tools/tasks/hashcat.yml
+++ b/roles/cracking_tools/tasks/hashcat.yml
@@ -72,6 +72,29 @@
             state: absent
           become: true
 
+    - name: Build hashcat Rust plugins serially
+      ansible.builtin.shell: |
+        . "$HOME/.cargo/env"
+        plugins=()
+        for manifest in Rust/bridges/*/Cargo.toml; do
+          [ -f "$manifest" ] || continue
+          crate=${manifest#Rust/bridges/}
+          plugins+=("bridges/subs/${crate%/Cargo.toml}.so")
+        done
+        for manifest in Rust/feeds/*/Cargo.toml; do
+          [ -f "$manifest" ] || continue
+          crate=${manifest#Rust/feeds/}
+          plugins+=("feeds/rust_${crate%/Cargo.toml}.so")
+        done
+        if [ -n "${plugins[*]}" ]; then
+          make -j1 "${plugins[@]}"
+        fi
+      args:
+        chdir: /opt/hashcat
+        creates: /opt/hashcat/hashcat
+        executable: /bin/bash
+      become: true
+
     - name: Build hashcat
       ansible.builtin.shell: |
         . "$HOME/.cargo/env"


### PR DESCRIPTION
**Key Changes:**

- Serialize build of hashcat Rust plugins to avoid parallel build issues
- Dynamically discover and build plugin targets from Cargo manifests
- Improve idempotency by skipping plugin build when the hashcat binary exists
- Update documentation to reflect the new serial plugin build step

**Added:**

- Serial Rust plugin compilation step in the Ansible role - roles/cracking_tools/tasks/hashcat.yml
  - Sources Cargo environment, discovers Rust plugin crates under Rust/bridges/* and Rust/feeds/*, maps them to .so targets, and invokes make -j1 for deterministic, serial builds
  - Executes in /opt/hashcat using bash with elevated privileges
  - Uses creates: /opt/hashcat/hashcat to prevent unnecessary rebuilds on subsequent runs

**Changed:**

- Documentation updated to list the serial build of hashcat Rust plugins - roles/cracking_tools/README.md